### PR TITLE
action: report test results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,11 @@ jobs:
         run: ./gradlew assemble
       - name: Test
         run: ./gradlew test && ./gradlew -p "android-test" test
+      - name: Debug
+        run: find . -name 'TEST-*.xml' -ls
       - name: Store test results
         if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: test-results
           path: "**/build/test-results/{test,testRelease*}/TEST-*.xml"
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,6 @@ jobs:
         run: ./gradlew assemble
       - name: Test
         run: ./gradlew test && ./gradlew -p "android-test" test
-      - name: Debug
-        run: find . -name 'TEST-*.xml' -ls
       - name: Store test results
         if: success() || failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,5 +25,5 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: "build/test-results/test/TEST-*.xml"
+          path: "**/build/test-results/{test,testRelease*}/TEST-*.xml"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,10 @@ jobs:
         run: ./gradlew assemble
       - name: Test
         run: ./gradlew test && ./gradlew -p "android-test" test
-        
+      - name: Store test results
+        if: success() || failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: "build/test-results/test/TEST-*.xml"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,6 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: test-results
-          path: "**/build/test-results/{test,testRelease*}/TEST-*.xml"
+          path: |
+            **/build/test-results/testRelease*/TEST-*.xml
+            **/build/test-results/test/TEST-*.xml

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -12,7 +12,7 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-      - uses: elastic/apm-pipeline-library/.github/actions/test-report@gh_actions
+      - uses: elastic/apm-pipeline-library/.github/actions/test-report@current
         with:
           artifact: test-results            # artifact name
           name: JUnit Tests                 # Name of the check run which will be created

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -12,7 +12,7 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-      - uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226
+      - uses: elastic/apm-pipeline-library/.github/actions/test-report@gh_actions
         with:
           artifact: test-results            # artifact name
           name: JUnit Tests                 # Name of the check run which will be created

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -1,0 +1,20 @@
+---
+## Workflow to process the JUnit test results and add a report to the checks.
+name: Test Report
+on:
+  workflow_run:
+    workflows:
+      - Continous Integration
+    types:
+      - completed
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny/test-reporter@c9b3d0e2bd2a4e96aaf424dbaa31c46b42318226
+        with:
+          artifact: test-results            # artifact name
+          name: JUnit Tests                 # Name of the check run which will be created
+          path: "**/*.xml"                  # Path to test results (inside artifact .zip)
+          reporter: java-junit              # Format of test results


### PR DESCRIPTION
Blocked by https://github.com/elastic/apm-pipeline-library/pull/1941

### What

Store the test results so they can be later on reported in the GitHub check.


### Why

Help to visualise the test reports


### Follow up

We will likely enable support for the OTEL reporting, as done in https://github.com/elastic/apm-pipeline-library/blob/main/.github/workflows/opentelemetry.yml so GitHub actions will represented as traces, in addition to also reporting the test results. But something to be done in the near future 