### PR TITLE
ci: script to install tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ lint/generated/
 lint/outputs/
 lint/tmp/
 # lint/reports/
+.android-sdk

--- a/install-android-sdk.sh
+++ b/install-android-sdk.sh
@@ -24,11 +24,6 @@ rm ${COMMAND_LINE_TOOLS_ZIP}
 mv cmdline-tools latest
 ln -s ${SDKDIR}/cmdline-tools/latest ${SDKDIR}/tools
 
-echo Installing emulator...
-yes | ${ANDROID_HOME}/tools/bin/sdkmanager --install platform-tools emulator
-
 echo Installing platform SDK...
 yes | ${ANDROID_HOME}/tools/bin/sdkmanager --install "platforms;android-33"
 
-echo Starting ADB...
-${ANDROID_HOME}/platform-tools/adb devices

--- a/install-android-sdk.sh
+++ b/install-android-sdk.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -e
+
+SDKDIR=$PWD/.android-sdk
+export ANDROID_SDK_ROOT=${SDKDIR}
+export ANDROID_HOME=${SDKDIR}
+export ANDROID_AVD_HOME=${SDKDIR}/avd
+
+mkdir ${SDKDIR}
+mkdir ${SDKDIR}/cmdline-tools
+
+echo Downloading Android SDK...
+cd ${SDKDIR}/cmdline-tools
+COMMAND_LINE_TOOLS_ZIP=${SDKDIR}/commandlinetools.zip
+# https://developer.android.com/studio#command-tools
+TYPE=linux
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  TYPE=mac
+fi
+curl -q https://dl.google.com/android/repository/commandlinetools-${TYPE}-8512546_latest.zip -o ${COMMAND_LINE_TOOLS_ZIP}
+unzip ${COMMAND_LINE_TOOLS_ZIP}
+rm ${COMMAND_LINE_TOOLS_ZIP}
+mv cmdline-tools latest
+ln -s ${SDKDIR}/cmdline-tools/latest ${SDKDIR}/tools
+
+echo Installing emulator...
+yes | ${ANDROID_HOME}/tools/bin/sdkmanager --install platform-tools emulator
+
+echo Installing platform SDK...
+yes | ${ANDROID_HOME}/tools/bin/sdkmanager --install "platforms;android-33"
+
+echo Starting ADB...
+${ANDROID_HOME}/platform-tools/adb devices

--- a/install-android-sdk.sh
+++ b/install-android-sdk.sh
@@ -24,6 +24,11 @@ rm ${COMMAND_LINE_TOOLS_ZIP}
 mv cmdline-tools latest
 ln -s ${SDKDIR}/cmdline-tools/latest ${SDKDIR}/tools
 
+echo Installing emulator...
+yes | ${ANDROID_HOME}/tools/bin/sdkmanager --install platform-tools emulator
+
 echo Installing platform SDK...
 yes | ${ANDROID_HOME}/tools/bin/sdkmanager --install "platforms;android-33"
 
+echo Starting ADB...
+${ANDROID_HOME}/platform-tools/adb devices


### PR DESCRIPTION
Ideally the release will need to run:


```bash
$ install-android-sdk.sh
$ export PATH=${PATH}:$PWD/.android-sdk/tools/bin/
$ export ANDROID_HOME=$PWD/.android-sdk
```

Then I ran `./gradlew test` locally and it worked like a charm

```
 '/Users/vmartinez/work/src/github.com/elastic/apm-agent-android/.android-sdk/tools')

BUILD SUCCESSFUL in 1m 14s
120 actionable tasks: 114 executed, 6 up-to-date
```