### PR TITLE
Add `page_header.html`

### DIFF
--- a/docs/faq.asciidoc
+++ b/docs/faq.asciidoc
@@ -1,5 +1,5 @@
 [[faq]]
-== Frequently Asked Questions
+== Frequently asked questions
 
 [float]
 [[faq-how-does-it-work]]

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -6,7 +6,7 @@ It has a default configuration that suits most common use cases
 and built-in support for popular frameworks and technologies.
 The agent is built on top of https://opentelemetry.io/[OpenTelemetry],
 enabling you to add custom instrumentation with the
-https://opentelemetry.io/docs/instrumentation/java/manual/[Java API][OpenTelemetry Java API].
+https://opentelemetry.io/docs/instrumentation/java/manual/[OpenTelemetry Java API].
 
 
 [float]

--- a/docs/page_header.html
+++ b/docs/page_header.html
@@ -1,0 +1,2 @@
+You are looking at preliminary documentation for a future release.
+This project is still in development; do not use it in a production environment.


### PR DESCRIPTION
This PR adds a header to every documentation page explaining that this product is still under development. See the iOS docs for an example: https://www.elastic.co/guide/en/apm/agent/swift/current/index.html.

EDIT: I also added two small fixes to the docs.