### PR TITLE
58 otel desugaring

### DIFF
--- a/android-test/app/build.gradle
+++ b/android-test/app/build.gradle
@@ -24,7 +24,7 @@ android {
     }
     defaultConfig {
         applicationId "co.elastic.apm.android.test"
-        minSdk 24
+        minSdk 26
         targetSdk 32
         versionCode 1
         versionName "1.0"

--- a/android-test/plugin-test/src/test/java/co/elastic/apm/android/plugin/testutils/buildgradle/block/impl/android/DefaultConfigBlockBuilder.java
+++ b/android-test/plugin-test/src/test/java/co/elastic/apm/android/plugin/testutils/buildgradle/block/impl/android/DefaultConfigBlockBuilder.java
@@ -36,7 +36,7 @@ public class DefaultConfigBlockBuilder implements BlockBuilder {
         addNewLine(builder);
         builder.append("applicationId '").append(applicationId).append("'");
         addNewLine(builder);
-        builder.append("minSdk 24");
+        builder.append("minSdk 26");
         addNewLine(builder);
         builder.append("versionName '").append(versionName).append("'");
         addNewLine(builder);

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 ext {
     jvmCompatibility = JavaVersion.VERSION_1_8
-    androidMinSdk = 24
+    androidMinSdk = 26
     androidCompileSdk = 32
     openTelemetry_version = "1.16.0"
     androidAnnotations_version = "1.4.0"

--- a/docs/supported-technologies.asciidoc
+++ b/docs/supported-technologies.asciidoc
@@ -20,6 +20,16 @@ This section lists all supported technologies.
 |===
 
 [float]
+[[supported-android-runtime-versions]]
+=== Android runtime versions
+
+|===
+|Supported versions
+
+| API >= 26
+|===
+
+[float]
 [[supported-languages]]
 === Languages
 


### PR DESCRIPTION
Related to #58 

Dropping support for Android API < 26 to help making the set up process easier. Might evaluate further options in the future that don't involve dropping < 26 support if needed.