### PR TITLE
action: use snapshoty simple

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,6 @@ jobs:
         run: ./gradlew assemble
       - name: Test
         run: ./tests.sh
-      - name: Publish snaphosts
-        uses: elastic/apm-pipeline-library/.github/actions/snapshoty-simple@feature/use-snapshoty-with-docker
-        with:
-          config: '.ci/snapshoty.yml'
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
       - name: Store test results
         if: success() || failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,6 @@ on:
 permissions:
   contents: read
 
-env:
-  GCS_ACCOUNT_SECRET: 'secret/observability-team/ci/snapshoty'
-  DOCKER_REGISTRY_SECRET: 'secret/observability-team/ci/docker-registry/prod'
-
 jobs:
   process:
     runs-on: ubuntu-latest
@@ -26,33 +22,13 @@ jobs:
         run: ./gradlew assemble
       - name: Test
         run: ./tests.sh
-      - uses: elastic/apm-pipeline-library/.github/actions/docker-login@current
-        with:
-          registry: docker.elastic.co
-          secret: ${{ env.DOCKER_REGISTRY_SECRET }}
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-      - uses: hashicorp/vault-action@v2
-        with:
-          url: ${{ secrets.VAULT_ADDR }}
-          roleId: ${{ secrets.VAULT_ROLE_ID }}
-          secretId: ${{ secrets.VAULT_SECRET_ID }}
-          method: approle
-          secrets: |
-            ${{ env.GCS_ACCOUNT_SECRET }} client_email | GCS_CLIENT_EMAIL ;
-            ${{ env.GCS_ACCOUNT_SECRET }} private_key | GCS_PRIVATE_KEY ;
-            ${{ env.GCS_ACCOUNT_SECRET }} private_key_id | GCS_PRIVATE_KEY_ID ;
-            ${{ env.GCS_ACCOUNT_SECRET }} project_id | GCS_PROJECT
       - name: Publish snaphosts
-        uses: elastic/apm-pipeline-library/.github/actions/snapshoty@current
+        uses: elastic/apm-pipeline-library/.github/actions/snapshoty-simple@current
         with:
           config: '.ci/snapshoty.yml'
-          bucketName: 'oblt-artifacts'
-          gcsClientEmail: '${{ env.GCS_CLIENT_EMAIL }}'
-          gcsPrivateKey: '${{ env.GCS_PRIVATE_KEY }}'
-          gcsPrivateKeyId: '${{ env.GCS_PRIVATE_KEY_ID }}'
-          gcsProject: '${{ env.GCS_PROJECT }}'
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
       - name: Store test results
         if: success() || failure()
         uses: actions/upload-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Test
         run: ./tests.sh
       - name: Publish snaphosts
-        uses: elastic/apm-pipeline-library/.github/actions/snapshoty-simple@current
+        uses: elastic/apm-pipeline-library/.github/actions/snapshoty-simple@feature/use-snapshoty-with-docker
         with:
           config: '.ci/snapshoty.yml'
           vaultUrl: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -5,6 +5,7 @@ on:
   workflow_run:
     workflows:
       - Continous Integration
+      - snapshoty
       - test-reporter
     types: [completed]
 

--- a/.github/workflows/snapshoty.yml
+++ b/.github/workflows/snapshoty.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Publish snaphosts
-        uses: elastic/apm-pipeline-library/.github/actions/snapshoty-simple@feature/use-snapshoty-with-docker
+        uses: elastic/apm-pipeline-library/.github/actions/snapshoty-simple@current
         with:
           config: '.ci/snapshoty.yml'
           vaultUrl: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/snapshoty.yml
+++ b/.github/workflows/snapshoty.yml
@@ -1,0 +1,21 @@
+name: snapshoty
+
+on:
+  push:
+    branches:
+      - "main"
+
+permissions:
+  contents: read
+
+jobs:
+  process:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish snaphosts
+        uses: elastic/apm-pipeline-library/.github/actions/snapshoty-simple@feature/use-snapshoty-with-docker
+        with:
+          config: '.ci/snapshoty.yml'
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}


### PR DESCRIPTION
### What

Simplify the daily snapshots publishing by using the composite action.

It runs on push to `main`
Secrets are not available for PRs coming from forked repos.


### Why

Delegate the implementation details to the composite action.
Avoid errors when running PRs from forked repo


### Follow ups

Support for PRs but for now we only care about snapshots from the main branch.
Change branch to current in the action version

### Issues
Depends on https://github.com/elastic/apm-pipeline-library/pull/2016
