### PR TITLE
action: generate artifacts for snapshoty

### DIFF
--- a/.github/workflows/snapshoty.yml
+++ b/.github/workflows/snapshoty.yml
@@ -12,6 +12,9 @@ jobs:
   process:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+      - name: Assemble
+        run: ./gradlew assemble
       - name: Publish snaphosts
         uses: elastic/apm-pipeline-library/.github/actions/snapshoty-simple@current
         with:


### PR DESCRIPTION
Partially implemented in https://github.com/elastic/apm-agent-android/pull/89 but required to assemble the artifacts so they can be uploaded.

Rather than copying them from `.github/workflows/ci.yml` I decided to generate them again. That will avoid glueing different workflows for different events. 