### PR TITLE
action: run releases partially with GH actions

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -88,14 +88,12 @@ export COMMON_GRADLE_SIGNING_PARAMS="-Psigning.secretKeyRingFile=$SECRING_FILE -
 export COMMON_GRADLE_CONFIG_PARAMS="-Prelease=true -Pversion_override=${version_override_specifier}"
 export COMMON_GRADLE_DEPLOY_PARAMS="$COMMON_GRADLE_SIGNING_PARAMS $COMMON_GRADLE_CONFIG_PARAMS"
 
-if [ ${target_specifier} == 'all' ] || [ ${target_specifier} == 'mavenCentral' ]
-then
+if [[ "$target_specifier" == "all" ||  "$target_specifier" == "mavenCentral" ]]; then
   echo "--- Release the binaries to Maven Central"
   echo "./gradlew publishElasticPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository $COMMON_GRADLE_DEPLOY_PARAMS"
 fi
 
-if [ ${target_specifier} == 'all' ] || [ ${target_specifier} == 'pluginPortal' ]
-then
+if [[ "$target_specifier" == "all" ||  "$target_specifier" == "pluginPortal" ]]; then
   echo "--- Release the binaries to the Gradle Plugin portal"
   echo "./gradlew publishPlugins -Pgradle.publish.key=$PLUGIN_PORTAL_KEY -Pgradle.publish.secret=$PLUGIN_PORTAL_SECRET $COMMON_GRADLE_DEPLOY_PARAMS"
 fi

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -67,6 +67,8 @@ export PATH=${PATH}:$PWD/.android-sdk/tools/bin/
 export ANDROID_HOME=$PWD/.android-sdk
 
 ## Stage 4. Run release
+## TODO: let's stop here so we can test things work nicely until here
+exit 0
 
 set +x
 # Setting up common deploy params in env var

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -3,9 +3,6 @@
 ##  branch_specifier
 ##  target_specifier
 ##  version_override_specifier
-##  WORKSPACE
-##  VAULT_ROLE_ID
-##  VAULT_SECRET_ID
 
 set -e
 

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+## This script run the release given the different environment variables
+##  branch_specifier
+##  target_specifier
+##  version_override_specifier
+##  WORKSPACE
+##  VAULT_ROLE_ID
+##  VAULT_SECRET_ID
+
+set -e
+
+## Stage 1. Prepare context
+
+# Avoid detached HEAD since the release plugin requires to be on a branch
+git checkout -f ${branch_specifier}
+# Prepare a secure temp folder not shared between other jobs to store the key ring
+export TMP_WORKSPACE=$WORKSPACE"@tmp"
+export KEY_FILE=$TMP_WORKSPACE"/private.key"
+# Secure home for our keyring
+export GNUPGHOME=$TMP_WORKSPACE"/keyring"
+mkdir -p $GNUPGHOME
+chmod -R 700 $TMP_WORKSPACE
+# Make sure we delete this folder before leaving even in case of failure
+clean_up () {
+  ARG=$?
+  echo "Deleting tmp workspace"
+  rm -rf $TMP_WORKSPACE
+  echo "done"
+  exit $ARG
+}
+trap clean_up EXIT
+
+## Stage 2. Prepare secrets context
+# Retrieve the secrets we are going to use in this job
+set +x
+export VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+# Nexus credentials
+export ORG_GRADLE_PROJECT_sonatypeUsername=$(vault read -field=username secret/release/nexus)
+export ORG_GRADLE_PROJECT_sonatypePassword=$(vault read -field=password secret/release/nexus)
+
+# Gradle Plugin portal credentials
+export PLUGIN_PORTAL_KEY=$(vault read secret/release/gradle-plugin-portal -format=json  | jq -r .data.key)
+export PLUGIN_PORTAL_SECRET=$(vault read secret/release/gradle-plugin-portal -format=json  | jq -r .data.secret)
+
+# Signing keys
+vault read -field=key secret/release/signing >$KEY_FILE
+export KEYPASS=$(vault read -field=passphrase secret/release/signing)
+export KEY_ID=D88E42B4
+
+# Import the key into the keyring
+echo $KEYPASS | gpg --batch --import $KEY_FILE
+
+# Export secring
+export SECRING_FILE=$GNUPGHOME"/secring.gpg"
+gpg --pinentry-mode=loopback --passphrase $KEYPASS --export-secret-key $KEY_ID > $SECRING_FILE
+set -x
+# Configure the committer since the maven release requires to push changes to GitHub
+# This will help with the SLSA requirements.
+git config --global user.email "infra-root+apmmachine@elastic.co"
+git config --global user.name "apmmachine"
+
+## Stage 3. Prepare Android SDK dependency
+
+# Configure Android SDK using the script
+./install-android-sdk.sh
+export PATH=${PATH}:$PWD/.android-sdk/tools/bin/
+export ANDROID_HOME=$PWD/.android-sdk
+
+## Stage 4. Run release
+
+set +x
+# Setting up common deploy params in env var
+export COMMON_GRADLE_SIGNING_PARAMS="-Psigning.secretKeyRingFile=$SECRING_FILE -Psigning.password=$KEYPASS -Psigning.keyId=$KEY_ID"
+export COMMON_GRADLE_CONFIG_PARAMS="-Prelease=true -Pversion_override=${version_override_specifier}"
+export COMMON_GRADLE_DEPLOY_PARAMS="$COMMON_GRADLE_SIGNING_PARAMS $COMMON_GRADLE_CONFIG_PARAMS"
+
+if [ ${target_specifier} == 'all' ] || [ ${target_specifier} == 'mavenCentral' ]
+then
+  # Release the binaries to Maven Central
+  ./gradlew publishElasticPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository $COMMON_GRADLE_DEPLOY_PARAMS
+fi
+
+if [ ${target_specifier} == 'all' ] || [ ${target_specifier} == 'pluginPortal' ]
+then
+  # Release the binaries to the Gradle Plugin portal
+  ./gradlew publishPlugins -Pgradle.publish.key=$PLUGIN_PORTAL_KEY -Pgradle.publish.secret=$PLUGIN_PORTAL_SECRET $COMMON_GRADLE_DEPLOY_PARAMS
+fi
+set -x
+
+# Running post deploy process
+./gradlew postDeploy $COMMON_GRADLE_CONFIG_PARAMS

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -17,6 +17,11 @@ VAULT_SECRET_ID=$(vault read -field=secret-id secret/ci/elastic-observability-ro
 export VAULT_SECRET_ID
 VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-observability-robots-playground/internal-ci-approle)
 export VAULT_ADDR
+
+# Delete the vault specific accessing the ci vault
+unset VAULT_TOKEN
+rm ~/.vault-token || true
+
 ## Stage 1. Prepare context
 
 # Avoid detached HEAD since the release plugin requires to be on a branch

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -20,7 +20,6 @@ export VAULT_ADDR
 
 # Delete the vault specific accessing the ci vault
 unset VAULT_TOKEN
-rm ~/.vault-token || true
 
 ## Stage 1. Prepare context
 
@@ -46,7 +45,6 @@ trap clean_up EXIT
 ## Stage 2. Prepare secrets context
 # Retrieve the secrets we are going to use in this job
 set +x
-vault write -address="${VAULT_ADDR}" -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID"
 VAULT_TOKEN=$(vault write -address="${VAULT_ADDR}" -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
 export VAULT_TOKEN
 # Nexus credentials

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-## This script run the release given the different environment variables
+## This script runs the release given the different environment variables
 ##  branch_specifier
 ##  target_specifier
 ##  version_override_specifier

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -6,6 +6,9 @@
 
 set -e
 
+echo "--- Debug env variables"
+env | sort
+
 echo "--- Prepare vault context"
 set +x
 VAULT_ROLE_ID=$(vault read -field=role-id secret/ci/elastic-observability-robots-playground/internal-ci-approle)

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -3,6 +3,10 @@
 ##  branch_specifier
 ##  target_specifier
 ##  version_override_specifier
+##
+##  NOTE: *_SECRET env variables are masked, hence if you'd like to avoid any
+##        surprises please use the suffix _SECRET for those values that contain
+##        any sensitive data. Buildkite can mask those values automatically
 
 set -e
 
@@ -11,12 +15,12 @@ env | sort
 
 echo "--- Prepare vault context"
 set +x
-VAULT_ROLE_ID=$(vault read -field=role-id secret/ci/elastic-observability-robots-playground/internal-ci-approle)
-export VAULT_ROLE_ID
-VAULT_SECRET_ID=$(vault read -field=secret-id secret/ci/elastic-observability-robots-playground/internal-ci-approle)
-export VAULT_SECRET_ID
-VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-observability-robots-playground/internal-ci-approle)
-export VAULT_ADDR
+VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-observability-robots-playground/internal-ci-approle)
+export VAULT_ROLE_ID_SECRET
+VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-observability-robots-playground/internal-ci-approle)
+export VAULT_SECRET_ID_SECRET
+VAULT_ADDR_SECRET=$(vault read -field=vault-url secret/ci/elastic-observability-robots-playground/internal-ci-approle)
+export VAULT_ADDR_SECRET
 
 # Delete the vault specific accessing the ci vault
 unset VAULT_TOKEN
@@ -41,11 +45,11 @@ clean_up () {
 trap clean_up EXIT
 
 echo "--- Prepare keys context"
-# Retrieve the secrets we are going to use in this job
 set +x
-VAULT_TOKEN=$(vault write -address="${VAULT_ADDR}" -field=token auth/approle/login role_id="$VAULT_ROLE_ID" secret_id="$VAULT_SECRET_ID")
+VAULT_TOKEN=$(vault write -address="${VAULT_ADDR_SECRET}" -field=token auth/approle/login role_id="$VAULT_ROLE_ID_SECRET" secret_id="$VAULT_SECRET_ID_SECRET")
 export VAULT_TOKEN
-# Nexus credentials
+# Nexus credentials (they cannot use the _SECRET pattern since they are in-memory based)
+# See https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
 ORG_GRADLE_PROJECT_sonatypeUsername=$(vault read -field=username secret/release/nexus)
 export ORG_GRADLE_PROJECT_sonatypeUsername
 ORG_GRADLE_PROJECT_sonatypePassword=$(vault read -field=password secret/release/nexus)
@@ -59,17 +63,17 @@ export PLUGIN_PORTAL_SECRET
 
 # Signing keys
 vault read -field=key secret/release/signing >$KEY_FILE
-KEYPASS=$(vault read -field=passphrase secret/release/signing)
-export KEYPASS
-export KEY_ID=D88E42B4
+KEYPASS_SECRET=$(vault read -field=passphrase secret/release/signing)
+export KEYPASS_SECRET
+export KEY_ID_SECRET=D88E42B4
 unset VAULT_TOKEN
 
 # Import the key into the keyring
-echo "$KEYPASS" | gpg --batch --import "$KEY_FILE"
+echo "$KEYPASS_SECRET" | gpg --batch --import "$KEY_FILE"
 
 # Export secring
 export SECRING_FILE=$GNUPGHOME"/secring.gpg"
-gpg --pinentry-mode=loopback --passphrase "$KEYPASS" --export-secret-key $KEY_ID > "$SECRING_FILE"
+gpg --pinentry-mode=loopback --passphrase "$KEYPASS_SECRET" --export-secret-key $KEY_ID_SECRET > "$SECRING_FILE"
 set -x
 # Configure the committer since the maven release requires to push changes to GitHub
 # This will help with the SLSA requirements.
@@ -84,7 +88,7 @@ export ANDROID_HOME=$PWD/.android-sdk
 
 set +x
 # Setting up common deploy params in env var
-export COMMON_GRADLE_SIGNING_PARAMS="-Psigning.secretKeyRingFile=$SECRING_FILE -Psigning.password=$KEYPASS -Psigning.keyId=$KEY_ID"
+export COMMON_GRADLE_SIGNING_PARAMS="-Psigning.secretKeyRingFile=$SECRING_FILE -Psigning.password=$KEYPASS_SECRET -Psigning.keyId=$KEY_ID_SECRET"
 export COMMON_GRADLE_CONFIG_PARAMS="-Prelease=true -Pversion_override=${version_override_specifier}"
 export COMMON_GRADLE_DEPLOY_PARAMS="$COMMON_GRADLE_SIGNING_PARAMS $COMMON_GRADLE_CONFIG_PARAMS"
 

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -9,6 +9,11 @@
 
 set -e
 
+## Stage 0. Prepare vault context to access the secrets
+export VAULT_ROLE_ID=$(vault read -field=role-id secret/ci/elastic-observability-robots-playground/internal-ci-approle)
+export VAULT_SECRET_ID=$(vault read -field=secret-id secret/ci/elastic-observability-robots-playground/internal-ci-approle)
+export VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-observability-robots-playground/internal-ci-approle)
+
 ## Stage 1. Prepare context
 
 # Avoid detached HEAD since the release plugin requires to be on a branch

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -19,8 +19,8 @@ VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-observability
 export VAULT_ROLE_ID_SECRET
 VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-observability-robots-playground/internal-ci-approle)
 export VAULT_SECRET_ID_SECRET
-VAULT_ADDR_SECRET=$(vault read -field=vault-url secret/ci/elastic-observability-robots-playground/internal-ci-approle)
-export VAULT_ADDR_SECRET
+VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-observability-robots-playground/internal-ci-approle)
+export VAULT_ADDR
 
 # Delete the vault specific accessing the ci vault
 unset VAULT_TOKEN
@@ -46,7 +46,7 @@ trap clean_up EXIT
 
 echo "--- Prepare keys context"
 set +x
-VAULT_TOKEN=$(vault write -address="${VAULT_ADDR_SECRET}" -field=token auth/approle/login role_id="$VAULT_ROLE_ID_SECRET" secret_id="$VAULT_SECRET_ID_SECRET")
+VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID_SECRET" secret_id="$VAULT_SECRET_ID_SECRET")
 export VAULT_TOKEN
 # Nexus credentials (they cannot use the _SECRET pattern since they are in-memory based)
 # See https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -83,9 +83,6 @@ export PATH=${PATH}:$PWD/.android-sdk/tools/bin/
 export ANDROID_HOME=$PWD/.android-sdk
 
 ## Stage 4. Run release
-## TODO: let's stop here so we can test things work nicely until here
-exit 0
-
 set +x
 # Setting up common deploy params in env var
 export COMMON_GRADLE_SIGNING_PARAMS="-Psigning.secretKeyRingFile=$SECRING_FILE -Psigning.password=$KEYPASS -Psigning.keyId=$KEY_ID"
@@ -95,15 +92,15 @@ export COMMON_GRADLE_DEPLOY_PARAMS="$COMMON_GRADLE_SIGNING_PARAMS $COMMON_GRADLE
 if [ ${target_specifier} == 'all' ] || [ ${target_specifier} == 'mavenCentral' ]
 then
   # Release the binaries to Maven Central
-  ./gradlew publishElasticPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository $COMMON_GRADLE_DEPLOY_PARAMS
+  echo "./gradlew publishElasticPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository $COMMON_GRADLE_DEPLOY_PARAMS"
 fi
 
 if [ ${target_specifier} == 'all' ] || [ ${target_specifier} == 'pluginPortal' ]
 then
   # Release the binaries to the Gradle Plugin portal
-  ./gradlew publishPlugins -Pgradle.publish.key=$PLUGIN_PORTAL_KEY -Pgradle.publish.secret=$PLUGIN_PORTAL_SECRET $COMMON_GRADLE_DEPLOY_PARAMS
+  echo "./gradlew publishPlugins -Pgradle.publish.key=$PLUGIN_PORTAL_KEY -Pgradle.publish.secret=$PLUGIN_PORTAL_SECRET $COMMON_GRADLE_DEPLOY_PARAMS"
 fi
 set -x
 
 # Running post deploy process
-./gradlew postDeploy $COMMON_GRADLE_CONFIG_PARAMS
+echo "./gradlew postDeploy $COMMON_GRADLE_CONFIG_PARAMS"

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -90,14 +90,14 @@ export COMMON_GRADLE_DEPLOY_PARAMS="$COMMON_GRADLE_SIGNING_PARAMS $COMMON_GRADLE
 
 if [[ "$target_specifier" == "all" ||  "$target_specifier" == "mavenCentral" ]]; then
   echo "--- Release the binaries to Maven Central"
-  echo "./gradlew publishElasticPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository $COMMON_GRADLE_DEPLOY_PARAMS"
+  ./gradlew publishElasticPublicationToSonatypeRepository closeAndReleaseSonatypeStagingRepository $COMMON_GRADLE_DEPLOY_PARAMS
 fi
 
 if [[ "$target_specifier" == "all" ||  "$target_specifier" == "pluginPortal" ]]; then
   echo "--- Release the binaries to the Gradle Plugin portal"
-  echo "./gradlew publishPlugins -Pgradle.publish.key=$PLUGIN_PORTAL_KEY -Pgradle.publish.secret=$PLUGIN_PORTAL_SECRET $COMMON_GRADLE_DEPLOY_PARAMS"
+  ./gradlew publishPlugins -Pgradle.publish.key=$PLUGIN_PORTAL_KEY -Pgradle.publish.secret=$PLUGIN_PORTAL_SECRET $COMMON_GRADLE_DEPLOY_PARAMS
 fi
 set -x
 
 echo "--- Running post deploy process"
-echo "./gradlew postDeploy $COMMON_GRADLE_CONFIG_PARAMS"
+./gradlew postDeploy $COMMON_GRADLE_CONFIG_PARAMS

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -10,6 +10,7 @@
 set -e
 
 ## Stage 0. Prepare vault context to access the secrets
+set +x
 export VAULT_ROLE_ID=$(vault read -field=role-id secret/ci/elastic-observability-robots-playground/internal-ci-approle)
 export VAULT_SECRET_ID=$(vault read -field=secret-id secret/ci/elastic-observability-robots-playground/internal-ci-approle)
 export VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-observability-robots-playground/internal-ci-approle)

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -5,6 +5,7 @@ on:
   workflow_run:
     workflows:
       - Continous Integration
+      - release
       - snapshoty
       - test-reporter
     types: [completed]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
             command=.ci/release.sh
             channel='#apm-agent-mobile'
             branch_specifier=${{ inputs.branch_specifier || 'main' }}
-            target_specifier=${{ inputs.target_specifier || 'All' }}
+            target_specifier=${{ inputs.target_specifier || 'all' }}
             version_override_specifier=${{ inputs.version_override_specifier || '' }}
 
       ## ${{ github.event.after }} while use PRs for testing otherwsie ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Dump GitHub context
-        env:
-          GITHUB_CONTEXT: ${{ toJson(github) }}
-        run: echo "$GITHUB_CONTEXT"
       - name: Run Release
         # TODO: for testing purposes let's use the feature branch rather than current
         uses: elastic/apm-pipeline-library/.github/actions/buildkite@feature/avoid-guessing-git-commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
             target_specifier=${{ inputs.target_specifier || 'all' }}
             version_override_specifier=${{ inputs.version_override_specifier || '' }}
 
-      - if: ${{ always() }}
+      - if: ${{ success() }}
         uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
         with:
           url: ${{ secrets.VAULT_ADDR }}
@@ -62,3 +62,14 @@ jobs:
           channel: "#apm-agent-mobile"
           message: |
             :runner: [${{ github.repository }}] Release *${{ github.ref_name }}* has been triggered in Buildkite: (<${{ steps.buildkite.outputs.build }}|build>)
+
+      - if: ${{ failure() }}
+        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          channel: "#apm-agent-mobile"
+          message: |
+            :ghost: [${{ github.repository }}] Release *${{ github.ref_name }}* didn't get triggered in Buildkite.
+            Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
             repo=${{ github.repository }}
             repositoryUrl=${{ github.repositoryUrl }}
             commit=${{ github.event.after }}
-            command=./scripts/ci/bench.sh
+            command=.ci/release.sh
             channel='#apm-agent-mobile'
             branch_specifier=${{ inputs.branch_specifier || 'main' }}
             target_specifier=${{ inputs.target_specifier || 'All' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,5 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           channel: "#on-week-oblt-productivity"
           message: |
-            :large_green_circle: [${{ github.repository }}] Release *${{ github.ref_name }}* published."
-            Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)
+            :large_green_circle: [${{ github.repository }}] Release *${{ github.ref_name }}* published.
             Buildkite: (<${{ steps.buildkite.outputs.build }}|BK>)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,6 @@ jobs:
             commit=${{ github.sha }}
             command=./scripts/ci/bench.sh
             channel='#apm-agent-mobile'
-            branch_specifier=${{ inputs.branch_specifier }}
-            target_specifier=${{ inputs.target_specifier }}
+            branch_specifier=${{ inputs.branch_specifier || 'main' }}
+            target_specifier=${{ inputs.target_specifier || 'All' }}
             version_override_specifier=${{ inputs.version_override_specifier || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,11 +52,12 @@ jobs:
           printBuildLogs: false
           buildEnvVars: |
             repo=${{ github.repository }}
-            commit=${{ github.sha }}
+            repositoryUrl=${{ repositoryUrl }}
+            commit=${{ github.event.after }}
             command=./scripts/ci/bench.sh
             channel='#apm-agent-mobile'
             branch_specifier=${{ inputs.branch_specifier || 'main' }}
             target_specifier=${{ inputs.target_specifier || 'All' }}
             version_override_specifier=${{ inputs.version_override_specifier || '' }}
-            base_ref=${{ github.event.pull_request.base.ref }}
-            base_sha=${{ github.event.pull_request.base.sha }}
+
+## ${{ github.event.after }} while use PRs for testing otherwsie ${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,13 @@ jobs:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: observability-release-agent
-          waitFor: true
+          pipeline: observability-release
+          waitFor: false
           printBuildLogs: false
-          ## TODO: extra arguments to be passed to the build system
-          ## such as branch_specifier and target_specifier
+          buildEnvVars: |
+            commit=${{ github.sha }}
+            command=./scripts/ci/bench.sh
+            channel='#apm-agent-mobile'
+            branch_specifier=${{ inputs.branch_specifier }}
+            target_specifier=${{ inputs.target_specifier }}
+            version_override_specifier=${{ inputs.version_override_specifier || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,5 +67,4 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           channel: "#on-week-oblt-productivity"
           message: |
-            :large_green_circle: [${{ github.repository }}] Release *${{ github.ref_name }}* published.
-            Buildkite: (<${{ steps.buildkite.outputs.build }}|BK>)
+            :runner: [${{ github.repository }}] Release *${{ github.ref_name }}* has been triggered in Buildkite: (<${{ steps.buildkite.outputs.build }}|build>)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Run Release
+      - id: buildkite
+        name: Run Release
         # TODO: for testing purposes let's use the feature branch rather than current
         uses: elastic/apm-pipeline-library/.github/actions/buildkite@feature/avoid-guessing-git-commit
         with:
@@ -56,4 +57,16 @@ jobs:
             target_specifier=${{ inputs.target_specifier || 'All' }}
             version_override_specifier=${{ inputs.version_override_specifier || '' }}
 
-## ${{ github.event.after }} while use PRs for testing otherwsie ${{ github.sha }}
+      ## ${{ github.event.after }} while use PRs for testing otherwsie ${{ github.sha }}
+
+      - if: ${{ success() }}
+        uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
+        with:
+          url: ${{ secrets.VAULT_ADDR }}
+          roleId: ${{ secrets.VAULT_ROLE_ID }}
+          secretId: ${{ secrets.VAULT_SECRET_ID }}
+          channel: "#on-week-oblt-productivity"
+          message: |
+            :large_green_circle: [${{ github.repository }}] Release *${{ github.ref_name }}* published."
+            Build: (<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|here>)
+            Buildkite: (<${{ steps.buildkite.outputs.build }}|BK>)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJson(github) }}
+        run: echo "$GITHUB_CONTEXT"
       - name: Run Release
         # TODO: for testing purposes let's use the feature branch rather than current
         uses: elastic/apm-pipeline-library/.github/actions/buildkite@feature/avoid-guessing-git-commit

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,6 @@ permissions:
   contents: read
 
 on:
-  # TODO: for testing purposes on PRs
-  pull_request:
   workflow_dispatch:
     inputs:
       branch_specifier:
@@ -38,8 +36,7 @@ jobs:
     steps:
       - id: buildkite
         name: Run Release
-        # TODO: for testing purposes let's use the feature branch rather than current
-        uses: elastic/apm-pipeline-library/.github/actions/buildkite@feature/avoid-guessing-git-commit
+        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
         with:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
@@ -49,17 +46,14 @@ jobs:
           printBuildLogs: false
           buildEnvVars: |
             repo=${{ github.repository }}
-            repositoryUrl=${{ github.repositoryUrl }}
-            commit=${{ github.event.after }}
+            commit=${{ github.sha }}
             command=.ci/release.sh
             channel='#apm-agent-mobile'
             branch_specifier=${{ inputs.branch_specifier || 'main' }}
             target_specifier=${{ inputs.target_specifier || 'all' }}
             version_override_specifier=${{ inputs.version_override_specifier || '' }}
 
-      ## ${{ github.event.after }} while use PRs for testing otherwsie ${{ github.sha }}
-
-      - if: ${{ success() }}
+      - if: ${{ always() }}
         uses: elastic/apm-pipeline-library/.github/actions/slack-message@current
         with:
           url: ${{ secrets.VAULT_ADDR }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,3 +54,5 @@ jobs:
             branch_specifier=${{ inputs.branch_specifier || 'main' }}
             target_specifier=${{ inputs.target_specifier || 'All' }}
             version_override_specifier=${{ inputs.version_override_specifier || '' }}
+            base_ref=${{ github.event.pull_request.base.ref }}
+            base_sha=${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,8 @@ permissions:
   contents: read
 
 on:
+  # TODO: for testing purposes on PRs
+  pull_request:
   workflow_dispatch:
     inputs:
       branch_specifier:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           printBuildLogs: false
           buildEnvVars: |
             repo=${{ github.repository }}
-            repositoryUrl=${{ repositoryUrl }}
+            repositoryUrl=${{ github.repositoryUrl }}
             commit=${{ github.event.after }}
             command=./scripts/ci/bench.sh
             channel='#apm-agent-mobile'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,6 +47,7 @@ jobs:
           waitFor: false
           printBuildLogs: false
           buildEnvVars: |
+            repo=${{ github.repository }}
             commit=${{ github.sha }}
             command=./scripts/ci/bench.sh
             channel='#apm-agent-mobile'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,47 @@
+---
+name: release
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch_specifier:
+        description: The branch to release ex. main or 0.6.
+        required: true
+        default: "main"
+        type: string
+
+      target_specifier:
+        description: Specify which repo to deploy, all by default.
+        required: true
+        default: "all"
+        type: choice
+        options:
+          - "all"
+          - "mavenCentral"
+          - "pluginPortal"
+
+      version_override_specifier:
+        description: If set, this version will override the agent's gradle.properties version
+        required: false
+        type: string
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run Release
+        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+        with:
+          vaultUrl: ${{ secrets.VAULT_ADDR }}
+          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
+          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          pipeline: observability-release-agent
+          waitFor: true
+          printBuildLogs: false
+          ## TODO: extra arguments to be passed to the build system
+          ## such as branch_specifier and target_specifier

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,8 @@ jobs:
 
     steps:
       - name: Run Release
-        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+        # TODO: for testing purposes let's use the feature branch rather than current
+        uses: elastic/apm-pipeline-library/.github/actions/buildkite@feature/avoid-guessing-git-commit
         with:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}

--- a/.github/workflows/snapshoty.yml
+++ b/.github/workflows/snapshoty.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "main"
+  pull_request:
 
 permissions:
   contents: read

--- a/.github/workflows/snapshoty.yml
+++ b/.github/workflows/snapshoty.yml
@@ -23,9 +23,3 @@ jobs:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          waitFor: false
-          printBuildLogs: false
-          buildEnvVars: |
-            commit=${{ github.sha }}
-            command=./scripts/ci/bench.sh
-            channel='#apm-agent-mobile'

--- a/.github/workflows/snapshoty.yml
+++ b/.github/workflows/snapshoty.yml
@@ -22,3 +22,9 @@ jobs:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
+          waitFor: false
+          printBuildLogs: false
+          buildEnvVars: |
+            commit=${{ github.sha }}
+            command=./scripts/ci/bench.sh
+            channel='#apm-agent-mobile'

--- a/.github/workflows/snapshoty.yml
+++ b/.github/workflows/snapshoty.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - "main"
-  pull_request:
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,4 +73,12 @@ You can run the following command to run all the unit tests available:
 
 ### Releasing
 
-// To do: Release process
+The release steps have been defined in `.ci/release.sh` which it gets triggered within the BuildKite context.
+
+Releases are triggered manually using GitHub actions, and the GitHub action is the one contacting BuildKite.
+To run a release then
+* Navigate to the [GitHub job](https://github.com/elastic/apm-agent-android/actions/workflows/release.yml)
+* Choose Run workflow.
+* Fill the form and click `Run workflow` and wait for a few minutes to complete
+
+And email/slack message will be sent with the outcome.


### PR DESCRIPTION
### What

Use GitHub actions to release this project. 

### Why

Jenkins will be decommissioned in the near future, hence there is a need to implement the release outside of Jenkins. BuildKite is the one in charge of running releases. Hence, this proposal will use BK and hide the implementations by facilitating the release process through GH actions.

### Issues

Requires https://github.com/elastic/apm-pipeline-library/pull/2033


### How to use it?

Go to https://github.com/elastic/apm-agent-android/actions/workflows/release.yml
Choose the parameters
Then
1) You will receive a notification in slack
<img width="524" alt="image" src="https://user-images.githubusercontent.com/2871786/216039336-7d5336d7-d649-4905-b958-1a495d06e4af.png">

2) Then you can see the build running in BK:

<img width="492" alt="image" src="https://user-images.githubusercontent.com/2871786/216039435-86e8fc04-50a7-4cc7-816e-03c35e1c1a09.png">

3) And get a slack notification with the release status


### Follows up

- Create BK definition within this project for running the release, so there is no need to use any other GitHub repository
- Export Buildkite builds to a private Google Bucket or similar place, so there is no need to access Buildkite for queering the logs. Or even use Elastic for digesting those logs in favour of avoiding context switching in the CI. To be revisited.
