### PR TITLE
release: define buildkite pipeline

### DIFF
--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -1,0 +1,11 @@
+agents:
+  provider: "gcp"
+
+steps:
+  - label: "Run the release"
+    commands: .ci/release.sh
+
+notify:
+  - slack:
+      channels:
+        - "#apm-agent-mobile"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,14 +41,10 @@ jobs:
           vaultUrl: ${{ secrets.VAULT_ADDR }}
           vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
           vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: observability-release
+          pipeline: apm-agent-android-release
           waitFor: false
           printBuildLogs: false
           buildEnvVars: |
-            repo=${{ github.repository }}
-            commit=${{ github.sha }}
-            command=.ci/release.sh
-            channel='#apm-agent-mobile'
             branch_specifier=${{ inputs.branch_specifier || 'main' }}
             target_specifier=${{ inputs.target_specifier || 'all' }}
             version_override_specifier=${{ inputs.version_override_specifier || '' }}


### PR DESCRIPTION
Caused by https://github.com/elastic/apm-agent-android/pull/104 so we can use the specific release pipeline in Buildkite.

This will be merged only once we validate the first release has done correctly in BK using the playground.