### PR TITLE
release dry run report logs to google bucket

### DIFF
--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -3,7 +3,12 @@ agents:
 
 steps:
   - label: "Run the release"
-    commands: .ci/release.sh
+    key: "release"
+    commands: .ci/release.sh | tee release.out
+
+  - label: "Upload the logs"
+    depends_on: "release"
+    commands: .ci/upload-logs.sh release.out
 
 notify:
   - slack:

--- a/.ci/upload-logs.sh
+++ b/.ci/upload-logs.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+## This script uploads the given logs to a google bucket
+##
+
+# Let's avoid failing the build
+set +e
+
+ls -l $1 || true
+echo 'TBC upload artifacts to google'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,11 @@ on:
         required: false
         type: string
 
+      dry_run:
+        description: If set, this will not run a release but run a dry-run
+        default: false
+        type: boolean
+
 jobs:
   release:
     name: Release
@@ -48,6 +53,7 @@ jobs:
             branch_specifier=${{ inputs.branch_specifier || 'main' }}
             target_specifier=${{ inputs.target_specifier || 'all' }}
             version_override_specifier=${{ inputs.version_override_specifier || '' }}
+            dry_run=${{ inputs.dry_run || 'false' }}
 
       - if: ${{ success() }}
         uses: elastic/apm-pipeline-library/.github/actions/slack-message@current


### PR DESCRIPTION
### What

Support dry-run executions so we can ensure all the moving pieces (access to secrets, gpg configuration, tools installation, git checkout) work as expected.

Additionally, I added the upload-artifact script to google (to be implemented in a follow up) so it can help us to see those logs somewhere else without the need to access to Buildkite.