### PR TITLE
release: use new vault secrets

### DIFF
--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -15,11 +15,11 @@ env | sort
 
 echo "--- Prepare vault context"
 set +x
-VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-observability-robots-playground/internal-ci-approle)
+VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-apm-agent-android/internal-ci-approle)
 export VAULT_ROLE_ID_SECRET
-VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-observability-robots-playground/internal-ci-approle)
+VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-apm-agent-android/internal-ci-approle)
 export VAULT_SECRET_ID_SECRET
-VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-observability-robots-playground/internal-ci-approle)
+VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-apm-agent-android/internal-ci-approle)
 export VAULT_ADDR
 
 # Delete the vault specific accessing the ci vault

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,3 +82,7 @@ To run a release then
 * Fill the form and click `Run workflow` and wait for a few minutes to complete
 
 And email/slack message will be sent with the outcome.
+
+#### Further details
+
+* There are specific vault secrets accessible only in `secret/ci/elastic-apm-agent-android`


### PR DESCRIPTION
No more pipeline helper in another repository, hence the vault secrets should point to the repository itself.