### PR TITLE
release: upload artifacts

### DIFF
--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -5,10 +5,7 @@ steps:
   - label: "Run the release"
     key: "release"
     commands: .ci/release.sh | tee release.out
-
-  - label: "Upload the logs"
-    depends_on: "release"
-    commands: .ci/upload-logs.sh release.out
+    artifact_paths: "release.out"
 
 notify:
   - slack:

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -31,7 +31,7 @@ echo "--- Prepare release context"
 # Avoid detached HEAD since the release plugin requires to be on a branch
 git checkout -f "${branch_specifier}"
 # Prepare a secure temp folder not shared between other jobs to store the key ring
-export TMP_WORKSPACE=$(mktemp)
+export TMP_WORKSPACE=/tmp/secured
 export KEY_FILE=$TMP_WORKSPACE"/private.key"
 # Secure home for our keyring
 export GNUPGHOME=$TMP_WORKSPACE"/keyring"


### PR DESCRIPTION
`artifact_paths` seems to be the way to upload the artifacts though I need to understand whether the location is somehow predictable, so we can provide those details when the slack notification will happen