### PR TITLE
release: configure jdk before androidsdk

### DIFF
--- a/.buildkite/release.yml
+++ b/.buildkite/release.yml
@@ -4,7 +4,7 @@ agents:
 steps:
   - label: "Run the release"
     key: "release"
-    commands: .ci/release.sh | tee release.out
+    commands: .ci/release-wrapper.sh
     artifact_paths: "release.out"
 
 notify:

--- a/.ci/release-wrapper.sh
+++ b/.ci/release-wrapper.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+.ci/release.sh | tee release.out

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -83,12 +83,6 @@ set -x
 git config --global user.email "infra-root+apmmachine@elastic.co"
 git config --global user.name "apmmachine"
 
-echo "--- Install Android SDK"
-# Configure Android SDK using the script
-./install-android-sdk.sh
-export PATH=${PATH}:$PWD/.android-sdk/tools/bin/
-export ANDROID_HOME=$PWD/.android-sdk
-
 echo "--- Install JDK11"
 JAVA_URL=https://jvm-catalog.elastic.co/jdk
 JAVA_HOME=$(pwd)/.openjdk11
@@ -98,6 +92,12 @@ curl -L --output /tmp/jdk.tar.gz "$JAVA_PKG"; \
   tar --extract --file /tmp/jdk.tar.gz --directory "$JAVA_HOME" --strip-components 1
 export JAVA_HOME
 export PATH=$JAVA_HOME/bin:$PATH
+
+echo "--- Install Android SDK"
+# Configure Android SDK using the script
+./install-android-sdk.sh
+export PATH=${PATH}:$PWD/.android-sdk/tools/bin/
+export ANDROID_HOME=$PWD/.android-sdk
 
 set +x
 # Setting up common deploy params in env var


### PR DESCRIPTION
Trying to solve the error with

```
JRROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
 
Please set the JAVA_HOME variable in your environment to match the
location of your Java installation.
 ```

Use release-wrapper script to apply https://buildkite.com/docs/pipelines/managing-log-output#storing-the-original-log and report the error accordingly otherwise if errorlevel=1 the pipeline won;t fail