### PR TITLE
Adding network information to logs

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -33,6 +33,8 @@ ${next_release_notes}
 ===== Features
 
 * Updating OpenTelemetry SDK to 1.27.0 where logs are stable: {pull}168[#168]
+* Updating OpenTelemetry SDK to 1.28.0 where the new disk buffering lib is present: {pull}170[#170]
+* Adding network connectivity attributes to logs: {pull}?[#?]
 ////
 
 [[release-notes-0.7.0]]

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -34,7 +34,7 @@ ${next_release_notes}
 
 * Updating OpenTelemetry SDK to 1.27.0 where logs are stable: {pull}168[#168]
 * Updating OpenTelemetry SDK to 1.28.0 where the new disk buffering lib is present: {pull}170[#170]
-* Adding network connectivity attributes to logs: {pull}?[#?]
+* Adding network connectivity attributes to logs: {pull}173[#173]
 ////
 
 [[release-notes-0.7.0]]

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/ElasticApmAgent.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/ElasticApmAgent.java
@@ -268,8 +268,8 @@ public final class ElasticApmAgent {
         SpanProcessor spanProcessor = signalConfiguration.getSpanProcessor();
         ComposeAttributesVisitor spanAttributesVisitor = AttributesVisitor.compose(
                 commonAttrVisitor,
-                new CarrierHttpAttributesVisitor(),
-                new ConnectionHttpAttributesVisitor()
+                ConnectionHttpAttributesVisitor.getInstance(),
+                new CarrierHttpAttributesVisitor()
         );
         ElasticSpanProcessor processor = new ElasticSpanProcessor(spanProcessor, spanAttributesVisitor);
         ComposableFilter<ReadableSpan> filter = new ComposableFilter<>();
@@ -288,7 +288,11 @@ public final class ElasticApmAgent {
                                                 Resource resource,
                                                 AttributesVisitor commonAttrVisitor) {
         LogRecordProcessor logProcessor = signalConfiguration.getLogProcessor();
-        ElasticLogRecordProcessor elasticProcessor = new ElasticLogRecordProcessor(logProcessor, commonAttrVisitor);
+        ComposeAttributesVisitor logAttributes = AttributesVisitor.compose(
+                commonAttrVisitor,
+                ConnectionHttpAttributesVisitor.getInstance()
+        );
+        ElasticLogRecordProcessor elasticProcessor = new ElasticLogRecordProcessor(logProcessor, logAttributes);
         ComposableFilter<LogRecordData> logFilter = new ComposableFilter<>();
         logFilter.addAllFilters(configuration.logFilters);
         elasticProcessor.setFilter(logFilter);

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/attributes/common/ConnectionHttpAttributesVisitor.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/attributes/common/ConnectionHttpAttributesVisitor.java
@@ -29,8 +29,16 @@ import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
 public class ConnectionHttpAttributesVisitor implements AttributesVisitor {
     private final Provider<NetworkService> networkServiceProvider;
+    private static ConnectionHttpAttributesVisitor instance;
 
-    public ConnectionHttpAttributesVisitor() {
+    public static ConnectionHttpAttributesVisitor getInstance() {
+        if (instance == null) {
+            instance = new ConnectionHttpAttributesVisitor();
+        }
+        return instance;
+    }
+
+    private ConnectionHttpAttributesVisitor() {
         networkServiceProvider = ServiceManager.getServiceProvider(Service.Names.NETWORK);
     }
 

--- a/android-test/app/src/test/java/co/elastic/apm/android/test/attributes/logs/GlobalAttributeTest.java
+++ b/android-test/app/src/test/java/co/elastic/apm/android/test/attributes/logs/GlobalAttributeTest.java
@@ -1,7 +1,9 @@
 package co.elastic.apm.android.test.attributes.logs;
 
 import org.junit.Test;
+import org.robolectric.annotation.Config;
 
+import co.elastic.apm.android.test.attributes.traces.common.AppsWithConnectivity;
 import co.elastic.apm.android.test.common.logs.Logs;
 import co.elastic.apm.android.test.testutils.base.BaseRobolectricTest;
 import io.opentelemetry.sdk.logs.data.LogRecordData;
@@ -14,6 +16,34 @@ public class GlobalAttributeTest extends BaseRobolectricTest {
 
         Logs.verifyRecord(log)
                 .hasAttribute("session.id");
+    }
+
+    @Config(application = AppsWithConnectivity.WithWifi.class)
+    @Test
+    public void whenALogIsCreated_andThereIsWifiConnectivity_verifyItHasWifiConnectivityParam() {
+        LogRecordData log = captureLog();
+
+        Logs.verifyRecord(log)
+                .hasAttribute("net.host.connection.type", "wifi");
+    }
+
+    @Config(application = AppsWithConnectivity.WithCellular.class)
+    @Test
+    public void whenALogIsCreated_andThereIsCellularConnectivity_verifyItHasCellularConnectivityParam() {
+        LogRecordData log = captureLog();
+
+        Logs.verifyRecord(log)
+                .hasAttribute("net.host.connection.type", "cell");
+    }
+
+    @Config(application = AppsWithConnectivity.WithCellularAndSubtype.class)
+    @Test
+    public void whenALogIsCreated_andThereIsCellularConnectivityWithSubtype_verifyItHasCellularConnectivityParam() {
+        LogRecordData log = captureLog();
+
+        Logs.verifyRecord(log)
+                .hasAttribute("net.host.connection.type", "cell")
+                .hasAttribute("net.host.connection.subtype", "EDGE");
     }
 
     private LogRecordData captureLog() {

--- a/android-test/app/src/test/java/co/elastic/apm/android/test/attributes/traces/common/AppsWithConnectivity.java
+++ b/android-test/app/src/test/java/co/elastic/apm/android/test/attributes/traces/common/AppsWithConnectivity.java
@@ -1,0 +1,71 @@
+package co.elastic.apm.android.test.attributes.traces.common;
+
+import static org.mockito.Mockito.doReturn;
+
+import android.Manifest;
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
+import android.telephony.TelephonyManager;
+
+import org.mockito.Mockito;
+import org.robolectric.Shadows;
+import org.robolectric.shadows.ShadowApplication;
+import org.robolectric.shadows.ShadowConnectivityManager;
+import org.robolectric.shadows.ShadowTelephonyManager;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import co.elastic.apm.android.test.testutils.MainApp;
+
+public final class AppsWithConnectivity {
+
+    public static class WithWifi extends MainApp {
+        @Override
+        public void onCreate() {
+            super.onCreate();
+            ShadowConnectivityManager shadowConnectivityManager = Shadows.shadowOf((ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE));
+            List<ConnectivityManager.NetworkCallback> callbacks = new ArrayList<>(shadowConnectivityManager.getNetworkCallbacks());
+            ConnectivityManager.NetworkCallback defaultNetworkCallback = callbacks.get(0);
+
+            NetworkCapabilities capabilities = Mockito.mock(NetworkCapabilities.class);
+            doReturn(true).when(capabilities).hasTransport(NetworkCapabilities.TRANSPORT_WIFI);
+            defaultNetworkCallback.onCapabilitiesChanged(Mockito.mock(Network.class), capabilities);
+        }
+    }
+
+    public static class WithCellular extends MainApp {
+        @Override
+        public void onCreate() {
+            super.onCreate();
+            ShadowConnectivityManager shadowConnectivityManager = Shadows.shadowOf((ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE));
+            List<ConnectivityManager.NetworkCallback> callbacks = new ArrayList<>(shadowConnectivityManager.getNetworkCallbacks());
+            ConnectivityManager.NetworkCallback defaultNetworkCallback = callbacks.get(0);
+
+            NetworkCapabilities capabilities = Mockito.mock(NetworkCapabilities.class);
+            doReturn(true).when(capabilities).hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR);
+            defaultNetworkCallback.onCapabilitiesChanged(Mockito.mock(Network.class), capabilities);
+        }
+    }
+
+    public static class WithCellularAndSubtype extends MainApp {
+        @Override
+        public void onCreate() {
+            super.onCreate();
+            ShadowConnectivityManager shadowConnectivityManager = Shadows.shadowOf((ConnectivityManager) getSystemService(Context.CONNECTIVITY_SERVICE));
+            ShadowTelephonyManager shadowTelephonyManager = Shadows.shadowOf((TelephonyManager) getSystemService(Context.TELEPHONY_SERVICE));
+            ShadowApplication shadowContext = Shadows.shadowOf(this);
+            shadowContext.grantPermissions(Manifest.permission.READ_PHONE_STATE);
+            List<ConnectivityManager.NetworkCallback> callbacks = new ArrayList<>(shadowConnectivityManager.getNetworkCallbacks());
+            ConnectivityManager.NetworkCallback defaultNetworkCallback = callbacks.get(0);
+
+            NetworkCapabilities capabilities = Mockito.mock(NetworkCapabilities.class);
+            doReturn(true).when(capabilities).hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR);
+            shadowTelephonyManager.setDataNetworkType(TelephonyManager.NETWORK_TYPE_EDGE);
+
+            defaultNetworkCallback.onCapabilitiesChanged(Mockito.mock(Network.class), capabilities);
+        }
+    }
+}


### PR DESCRIPTION
Closes #140 

This PR adds `net.host.connection.type` (and `net.host.connection.subtype` when available) to all log signals. These attr names arrive at ES as `network.connection.type` and `network.connection.subtype` respectively.