### PR TITLE
Session refactoring

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -32,7 +32,7 @@ ${next_release_notes}
 [float]
 ===== Features
 
-* New feature: {pull}000[#000]
+* Making Session ID generator configurable: {pull}178[#178]
 ////
 
 [[release-notes-0.8.0]]

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/ElasticApmAgent.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/ElasticApmAgent.java
@@ -145,8 +145,9 @@ public final class ElasticApmAgent {
         ElasticExceptionHandler.resetForTest();
         ConfigurationPollManager.resetForTest();
         Configurations.resetForTest();
-        ServiceManager.resetForTest();
         SessionManager.resetForTest();
+        ConnectionHttpAttributesVisitor.resetForTest();
+        ServiceManager.resetForTest();
         instance = null;
     }
 

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/ElasticApmConfiguration.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/ElasticApmConfiguration.java
@@ -29,8 +29,8 @@ import co.elastic.apm.android.sdk.features.persistence.PersistenceConfiguration;
 import co.elastic.apm.android.sdk.instrumentation.InstrumentationConfiguration;
 import co.elastic.apm.android.sdk.logs.tools.LogFilter;
 import co.elastic.apm.android.sdk.metrics.tools.MetricFilter;
-import co.elastic.apm.android.sdk.session.SessionIdProvider;
-import co.elastic.apm.android.sdk.session.impl.DefaultSessionIdProvider;
+import co.elastic.apm.android.sdk.session.SessionIdGenerator;
+import co.elastic.apm.android.sdk.session.impl.DefaultSessionIdGenerator;
 import co.elastic.apm.android.sdk.traces.http.HttpTraceConfiguration;
 import co.elastic.apm.android.sdk.traces.tools.SpanFilter;
 
@@ -40,7 +40,7 @@ public final class ElasticApmConfiguration {
     public final String serviceName;
     public final String serviceVersion;
     public final String deploymentEnvironment;
-    public final SessionIdProvider sessionIdProvider;
+    public final SessionIdGenerator sessionIdGenerator;
     public final SignalConfiguration signalConfiguration;
     public final PersistenceConfiguration persistenceConfiguration;
     public final List<SpanFilter> spanFilters;
@@ -59,7 +59,7 @@ public final class ElasticApmConfiguration {
         httpTraceConfiguration = builder.httpTraceConfiguration;
         serviceName = builder.serviceName;
         serviceVersion = builder.serviceVersion;
-        sessionIdProvider = builder.sessionIdProvider;
+        sessionIdGenerator = builder.sessionIdGenerator;
         instrumentationConfiguration = builder.instrumentationConfiguration;
         signalConfiguration = builder.signalConfiguration;
         deploymentEnvironment = builder.deploymentEnvironment;
@@ -76,7 +76,7 @@ public final class ElasticApmConfiguration {
         private String serviceName;
         private String serviceVersion;
         private String deploymentEnvironment;
-        private SessionIdProvider sessionIdProvider;
+        private SessionIdGenerator sessionIdGenerator;
         private SignalConfiguration signalConfiguration;
         private final Set<SpanFilter> spanFilters = new HashSet<>();
         private final Set<LogFilter> logFilters = new HashSet<>();
@@ -189,8 +189,8 @@ public final class ElasticApmConfiguration {
             if (instrumentationConfiguration == null) {
                 instrumentationConfiguration = InstrumentationConfiguration.allEnabled();
             }
-            if (sessionIdProvider == null) {
-                sessionIdProvider = new DefaultSessionIdProvider();
+            if (sessionIdGenerator == null) {
+                sessionIdGenerator = new DefaultSessionIdGenerator();
             }
             if (persistenceConfiguration == null) {
                 persistenceConfiguration = PersistenceConfiguration.builder().build();

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/ElasticApmConfiguration.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/ElasticApmConfiguration.java
@@ -153,6 +153,14 @@ public final class ElasticApmConfiguration {
         }
 
         /**
+         * The session ID generator will be used when a new session is created, the id provided by this generator will be the session ID.
+         * By default, a UUID is generated.
+         */
+        public void setSessionIdGenerator(SessionIdGenerator sessionIdGenerator) {
+            this.sessionIdGenerator = sessionIdGenerator;
+        }
+
+        /**
          * The span filter can be used to control which spans are exported and which shouldn't
          * leave the device. An implementation that always excludes all spans is essentially a way
          * to turn all spans off.

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/ElasticApmConfiguration.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/ElasticApmConfiguration.java
@@ -156,8 +156,9 @@ public final class ElasticApmConfiguration {
          * The session ID generator will be used when a new session is created, the id provided by this generator will be the session ID.
          * By default, a UUID is generated.
          */
-        public void setSessionIdGenerator(SessionIdGenerator sessionIdGenerator) {
+        public Builder setSessionIdGenerator(SessionIdGenerator sessionIdGenerator) {
             this.sessionIdGenerator = sessionIdGenerator;
+            return this;
         }
 
         /**

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/attributes/common/ConnectionHttpAttributesVisitor.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/attributes/common/ConnectionHttpAttributesVisitor.java
@@ -23,12 +23,11 @@ import co.elastic.apm.android.sdk.internal.services.Service;
 import co.elastic.apm.android.sdk.internal.services.ServiceManager;
 import co.elastic.apm.android.sdk.internal.services.network.NetworkService;
 import co.elastic.apm.android.sdk.internal.services.network.data.type.NetworkType;
-import co.elastic.apm.android.sdk.internal.utilities.providers.Provider;
 import io.opentelemetry.api.common.AttributesBuilder;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 
 public class ConnectionHttpAttributesVisitor implements AttributesVisitor {
-    private final Provider<NetworkService> networkServiceProvider;
+    private final NetworkService networkService;
     private static ConnectionHttpAttributesVisitor instance;
 
     public static ConnectionHttpAttributesVisitor getInstance() {
@@ -38,13 +37,17 @@ public class ConnectionHttpAttributesVisitor implements AttributesVisitor {
         return instance;
     }
 
+    public static void resetForTest() {
+        instance = null;
+    }
+
     private ConnectionHttpAttributesVisitor() {
-        networkServiceProvider = ServiceManager.getServiceProvider(Service.Names.NETWORK);
+        networkService = ServiceManager.get().getService(Service.Names.NETWORK);
     }
 
     @Override
     public void visit(AttributesBuilder builder) {
-        NetworkType networkType = networkServiceProvider.get().getType();
+        NetworkType networkType = networkService.getType();
         builder.put(SemanticAttributes.NET_HOST_CONNECTION_TYPE, networkType.getName());
         if (networkType.getSubTypeName() != null) {
             builder.put(SemanticAttributes.NET_HOST_CONNECTION_SUBTYPE, networkType.getSubTypeName());

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/internal/injection/AgentDependenciesInjector.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/internal/injection/AgentDependenciesInjector.java
@@ -22,10 +22,13 @@ import co.elastic.apm.android.sdk.internal.configuration.provider.Configurations
 import co.elastic.apm.android.sdk.internal.features.centralconfig.initializer.CentralConfigurationInitializer;
 import co.elastic.apm.android.sdk.internal.features.persistence.PersistenceInitializer;
 import co.elastic.apm.android.sdk.internal.time.ntp.NtpManager;
+import co.elastic.apm.android.sdk.session.SessionManager;
 
 public interface AgentDependenciesInjector {
 
     NtpManager getNtpManager();
+
+    SessionManager getSessionManager();
 
     CentralConfigurationInitializer getCentralConfigurationInitializer();
 

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/internal/injection/DefaultAgentDependenciesInjector.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/internal/injection/DefaultAgentDependenciesInjector.java
@@ -29,6 +29,7 @@ import co.elastic.apm.android.sdk.internal.features.centralconfig.initializer.Ce
 import co.elastic.apm.android.sdk.internal.features.centralconfig.poll.ConfigurationPollManager;
 import co.elastic.apm.android.sdk.internal.features.persistence.PersistenceInitializer;
 import co.elastic.apm.android.sdk.internal.time.ntp.NtpManager;
+import co.elastic.apm.android.sdk.session.SessionManager;
 
 public class DefaultAgentDependenciesInjector implements AgentDependenciesInjector {
     private final Context appContext;
@@ -44,6 +45,11 @@ public class DefaultAgentDependenciesInjector implements AgentDependenciesInject
     @Override
     public NtpManager getNtpManager() {
         return new NtpManager(appContext);
+    }
+
+    @Override
+    public SessionManager getSessionManager() {
+        return new SessionManager(configuration.sessionIdGenerator);
     }
 
     @Override

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/internal/services/network/NetworkService.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/internal/services/network/NetworkService.java
@@ -64,8 +64,12 @@ public class NetworkService extends ConnectivityManager.NetworkCallback implemen
     }
 
     @NotNull
-    public NetworkType getType() {
+    public synchronized NetworkType getType() {
         return networkType;
+    }
+
+    private synchronized void setType(NetworkType networkType) {
+        this.networkType = networkType;
     }
 
     @Nullable
@@ -86,7 +90,7 @@ public class NetworkService extends ConnectivityManager.NetworkCallback implemen
     @Override
     public void onCapabilitiesChanged(@NonNull Network network, @NonNull NetworkCapabilities networkCapabilities) {
         super.onCapabilitiesChanged(network, networkCapabilities);
-        networkType = getNetworkType(networkCapabilities);
+        setType(getNetworkType(networkCapabilities));
     }
 
     private NetworkType getNetworkType(NetworkCapabilities networkCapabilities) {
@@ -102,7 +106,7 @@ public class NetworkService extends ConnectivityManager.NetworkCallback implemen
     @Override
     public void onLost(@NonNull Network network) {
         super.onLost(network);
-        networkType = NetworkType.none();
+        setType(NetworkType.none());
     }
 
     private boolean canQueryCarrierInfo() {

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/session/SessionIdGenerator.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/session/SessionIdGenerator.java
@@ -21,15 +21,15 @@ package co.elastic.apm.android.sdk.session;
 import androidx.annotation.NonNull;
 
 /**
- * Provides an identifier for all the {@link io.opentelemetry.api.trace.Span}s created during a
- * period of time. The idea of a session is to provide a context that covers many transactions
- * that a user did in order to fulfil their needs using an application. For most apps, a session
+ * Generates an identifier for all the signals created during a period of time.
+ * The idea of a session is to provide a context that covers many transactions that a user
+ * did in order to fulfil their needs using an application. For most apps, a session
  * could start when the user opens the app, and end when the user closes the app, or when the
  * app is forced to get closed due to an unexpected error. But for other apps, such as a ticketing
  * app for a queue in a bank for example, the app will always be open, but a session might start when
  * a person starts the process to get a new ticket, and end when the ticket is printed.
  */
-public interface SessionIdProvider {
+public interface SessionIdGenerator {
     @NonNull
-    String getSessionId();
+    String generate();
 }

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/session/SessionManager.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/session/SessionManager.java
@@ -75,7 +75,7 @@ public final class SessionManager implements Initializable {
     }
 
     @NonNull
-    public String getSessionId() {
+    public synchronized String getSessionId() {
         verifySessionExpiration();
         if (sessionId == null) {
             sessionId = generateSessionId();
@@ -84,9 +84,13 @@ public final class SessionManager implements Initializable {
         return sessionId;
     }
 
+    public synchronized void forceRefreshId() {
+        sessionId = null;
+    }
+
     private void verifySessionExpiration() {
         if (systemTimeProvider.getCurrentTimeMillis() >= expireTimeMillis) {
-            sessionId = null;
+            forceRefreshId();
         }
     }
 

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/session/impl/DefaultSessionIdGenerator.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/session/impl/DefaultSessionIdGenerator.java
@@ -16,27 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.android.sdk.attributes.common;
+package co.elastic.apm.android.sdk.session.impl;
 
-import co.elastic.apm.android.sdk.attributes.AttributesVisitor;
-import co.elastic.apm.android.sdk.session.SessionManager;
-import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.api.common.AttributesBuilder;
+import androidx.annotation.NonNull;
 
-public class SessionAttributesVisitor implements AttributesVisitor {
-    private static final AttributeKey<String> SESSION_ID_ATTRIBUTE_KEY = AttributeKey.stringKey("session.id");
-    private final SessionManager sessionManager;
+import java.util.UUID;
 
-    public SessionAttributesVisitor() {
-        this.sessionManager = SessionManager.get();
-    }
+import co.elastic.apm.android.sdk.session.SessionIdGenerator;
 
+public class DefaultSessionIdGenerator implements SessionIdGenerator {
+    @NonNull
     @Override
-    public void visit(AttributesBuilder builder) {
-        builder.put(SESSION_ID_ATTRIBUTE_KEY, getSessionId());
-    }
-
-    private synchronized String getSessionId() {
-        return sessionManager.getSessionId();
+    public String generate() {
+        return UUID.randomUUID().toString();
     }
 }

--- a/android-sdk/src/test/java/co/elastic/apm/android/sdk/session/SessionManagerTest.java
+++ b/android-sdk/src/test/java/co/elastic/apm/android/sdk/session/SessionManagerTest.java
@@ -70,6 +70,19 @@ public class SessionManagerTest extends BaseTest implements Provider<Preferences
     }
 
     @Test
+    public void whenSessionIdIsRequestedAfterForcingIdRefresh_provideNewId() {
+        SessionManager sessionManager = getSessionManager();
+        String firstSessionId = sessionManager.getSessionId();
+
+        assertEquals(firstSessionId, sessionManager.getSessionId());
+
+        sessionManager.forceRefreshId();
+
+        assertNotEquals(firstSessionId, sessionManager.getSessionId());
+        assertNotNull(sessionManager.getSessionId());
+    }
+
+    @Test
     public void whenSessionIdIsRequestedAgainAfter30Min_provideNewId_andKeepItWhenLessThan30MinsTimePassed() {
         int initialTime = 1_000_000;
         SystemTimeProvider systemTimeProvider = getSystemTimeProvider(initialTime);

--- a/android-sdk/src/test/java/co/elastic/apm/android/sdk/session/SessionManagerTest.java
+++ b/android-sdk/src/test/java/co/elastic/apm/android/sdk/session/SessionManagerTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package co.elastic.apm.android.sdk.session.impl;
+package co.elastic.apm.android.sdk.session;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -33,28 +33,30 @@ import org.junit.Test;
 
 import java.util.concurrent.TimeUnit;
 
-import co.elastic.apm.android.sdk.internal.utilities.providers.LazyProvider;
-import co.elastic.apm.android.sdk.internal.utilities.providers.Provider;
 import co.elastic.apm.android.sdk.internal.services.preferences.PreferencesService;
 import co.elastic.apm.android.sdk.internal.time.SystemTimeProvider;
-import co.elastic.apm.android.sdk.session.SessionIdProvider;
+import co.elastic.apm.android.sdk.internal.utilities.providers.LazyProvider;
+import co.elastic.apm.android.sdk.internal.utilities.providers.Provider;
+import co.elastic.apm.android.sdk.session.impl.DefaultSessionIdGenerator;
 import co.elastic.apm.android.sdk.testutils.BaseTest;
 
-public class DefaultSessionIdProviderTest extends BaseTest implements Provider<PreferencesService> {
+public class SessionManagerTest extends BaseTest implements Provider<PreferencesService> {
     private PreferencesService preferencesService;
+    private SessionIdGenerator sessionIdGenerator;
     private static final String KEY_SESSION_ID = "session_id";
     private static final String KEY_SESSION_ID_EXPIRATION_TIME = "session_id_expiration_time";
 
     @Before
     public void setUp() {
         preferencesService = mock(PreferencesService.class);
+        sessionIdGenerator = new DefaultSessionIdGenerator();
     }
 
     @Test
     public void whenSessionIdIsRequested_provideNonEmptyId() {
-        SessionIdProvider sessionIdProvider = getSessionIdProvider();
+        SessionManager sessionManager = getSessionManager();
 
-        String sessionId = sessionIdProvider.getSessionId();
+        String sessionId = sessionManager.getSessionId();
 
         assertNotNull(sessionId);
         assertFalse(sessionId.isEmpty());
@@ -62,23 +64,23 @@ public class DefaultSessionIdProviderTest extends BaseTest implements Provider<P
 
     @Test
     public void whenSessionIdIsRequestedMultipleTimes_provideSameId() {
-        SessionIdProvider sessionIdProvider = getSessionIdProvider();
+        SessionManager sessionManager = getSessionManager();
 
-        assertEquals(sessionIdProvider.getSessionId(), sessionIdProvider.getSessionId());
+        assertEquals(sessionManager.getSessionId(), sessionManager.getSessionId());
     }
 
     @Test
     public void whenSessionIdIsRequestedAgainAfter30Min_provideNewId_andKeepItWhenLessThan30MinsTimePassed() {
         int initialTime = 1_000_000;
         SystemTimeProvider systemTimeProvider = getSystemTimeProvider(initialTime);
-        DefaultSessionIdProvider sessionIdProvider = getSessionIdProvider(systemTimeProvider);
+        SessionManager sessionManager = getSessionManager(systemTimeProvider);
 
-        String firstId = sessionIdProvider.getSessionId();
+        String firstId = sessionManager.getSessionId();
 
         // Should change after 30 mins
         addTimeInMillis(systemTimeProvider, TimeUnit.MINUTES.toMillis(30));
 
-        String secondId = sessionIdProvider.getSessionId();
+        String secondId = sessionManager.getSessionId();
 
         assertNotEquals(firstId, secondId);
 
@@ -86,7 +88,7 @@ public class DefaultSessionIdProviderTest extends BaseTest implements Provider<P
 
         addTimeInMillis(systemTimeProvider, TimeUnit.MINUTES.toMillis(10));
 
-        assertEquals(secondId, sessionIdProvider.getSessionId());
+        assertEquals(secondId, sessionManager.getSessionId());
     }
 
     private void addTimeInMillis(SystemTimeProvider systemTimeProvider, long extraTimeInMillis) {
@@ -103,21 +105,21 @@ public class DefaultSessionIdProviderTest extends BaseTest implements Provider<P
     public void whenSessionIdIsRequested_timeoutShouldResetToKeepTheSameIdForOther30mins() {
         int initialTime = 1_000_000;
         SystemTimeProvider systemTimeProvider = getSystemTimeProvider(initialTime);
-        DefaultSessionIdProvider sessionIdProvider = getSessionIdProvider(systemTimeProvider);
+        SessionManager sessionManager = getSessionManager(systemTimeProvider);
 
-        String firstId = sessionIdProvider.getSessionId();
+        String firstId = sessionManager.getSessionId();
 
         // Forward just before 30 mins.
         addTimeInMillis(systemTimeProvider, TimeUnit.MINUTES.toMillis(29));
 
-        assertEquals(firstId, sessionIdProvider.getSessionId());
+        assertEquals(firstId, sessionManager.getSessionId());
 
         // Timeout should reset after the previous call to request the id.
 
         // Forward another 29 mins:
         addTimeInMillis(systemTimeProvider, TimeUnit.MINUTES.toMillis(29));
 
-        assertEquals(firstId, sessionIdProvider.getSessionId());
+        assertEquals(firstId, sessionManager.getSessionId());
     }
 
     @Test
@@ -129,9 +131,9 @@ public class DefaultSessionIdProviderTest extends BaseTest implements Provider<P
         doReturn(existingSessionId).when(preferencesService).retrieveString(KEY_SESSION_ID);
         doReturn(existingExpireTimeMillis).when(preferencesService).retrieveLong(eq(KEY_SESSION_ID_EXPIRATION_TIME), anyLong());
 
-        DefaultSessionIdProvider sessionIdProvider = getSessionIdProvider(timeProvider);
+        SessionManager sessionManager = getSessionManager(timeProvider);
 
-        assertEquals(existingSessionId, sessionIdProvider.getSessionId());
+        assertEquals(existingSessionId, sessionManager.getSessionId());
     }
 
     @Test
@@ -143,9 +145,9 @@ public class DefaultSessionIdProviderTest extends BaseTest implements Provider<P
         doReturn(existingSessionId).when(preferencesService).retrieveString(KEY_SESSION_ID);
         doReturn(existingExpireTimeMillis).when(preferencesService).retrieveLong(eq(KEY_SESSION_ID_EXPIRATION_TIME), anyLong());
 
-        DefaultSessionIdProvider sessionIdProvider = getSessionIdProvider(timeProvider);
+        SessionManager sessionManager = getSessionManager(timeProvider);
 
-        assertNotEquals(existingSessionId, sessionIdProvider.getSessionId());
+        assertNotEquals(existingSessionId, sessionManager.getSessionId());
     }
 
     @Test
@@ -153,21 +155,21 @@ public class DefaultSessionIdProviderTest extends BaseTest implements Provider<P
         long initialSystemTime = 1_000_000_000;
         SystemTimeProvider timeProvider = getSystemTimeProvider(initialSystemTime);
 
-        DefaultSessionIdProvider sessionIdProvider = getSessionIdProvider(timeProvider);
+        SessionManager sessionManager = getSessionManager(timeProvider);
 
-        String generatedSessionId = sessionIdProvider.getSessionId();
+        String generatedSessionId = sessionManager.getSessionId();
         verify(preferencesService).store(KEY_SESSION_ID, generatedSessionId);
         verify(preferencesService).store(KEY_SESSION_ID_EXPIRATION_TIME, initialSystemTime + TimeUnit.MINUTES.toMillis(30));
     }
 
-    private DefaultSessionIdProvider getSessionIdProvider() {
-        return getSessionIdProvider(SystemTimeProvider.get());
+    private SessionManager getSessionManager() {
+        return getSessionManager(SystemTimeProvider.get());
     }
 
-    private DefaultSessionIdProvider getSessionIdProvider(SystemTimeProvider systemTimeProvider) {
-        DefaultSessionIdProvider sessionIdProvider = new DefaultSessionIdProvider(systemTimeProvider, LazyProvider.of(this));
-        sessionIdProvider.initialize();
-        return sessionIdProvider;
+    private SessionManager getSessionManager(SystemTimeProvider systemTimeProvider) {
+        SessionManager sessionManager = new SessionManager(systemTimeProvider, LazyProvider.of(this), sessionIdGenerator);
+        sessionManager.initialize();
+        return sessionManager;
     }
 
     @Override

--- a/android-test/app/src/test/java/co/elastic/apm/android/test/testutils/base/BaseRobolectricTestApplication.java
+++ b/android-test/app/src/test/java/co/elastic/apm/android/test/testutils/base/BaseRobolectricTestApplication.java
@@ -109,7 +109,7 @@ public class BaseRobolectricTestApplication extends Application implements Expor
         setUpNtpManager();
         setUpCentralConfigurationInitializer();
         persistenceInitializer = mock(PersistenceInitializer.class);
-        sessionManager = mock(SessionManager.class);
+        setUpSessionManager();
     }
 
     private void setUpCentralConfigurationInitializer() {
@@ -122,6 +122,11 @@ public class BaseRobolectricTestApplication extends Application implements Expor
         Clock clock = new TestElasticClock();
         ntpManager = mock(NtpManager.class);
         doReturn(clock).when(ntpManager).getClock();
+    }
+
+    private void setUpSessionManager() {
+        sessionManager = mock(SessionManager.class);
+        doReturn("SESSION-ID").when(sessionManager).getSessionId();
     }
 
     @Override

--- a/android-test/app/src/test/java/co/elastic/apm/android/test/testutils/base/BaseRobolectricTestApplication.java
+++ b/android-test/app/src/test/java/co/elastic/apm/android/test/testutils/base/BaseRobolectricTestApplication.java
@@ -29,6 +29,7 @@ import co.elastic.apm.android.sdk.internal.injection.AgentDependenciesInjector;
 import co.elastic.apm.android.sdk.internal.services.Service;
 import co.elastic.apm.android.sdk.internal.services.ServiceManager;
 import co.elastic.apm.android.sdk.internal.time.ntp.NtpManager;
+import co.elastic.apm.android.sdk.session.SessionManager;
 import co.elastic.apm.android.test.common.agent.AgentInitializer;
 import co.elastic.apm.android.test.common.logs.LogRecordExporterCaptor;
 import co.elastic.apm.android.test.common.metrics.MetricExporterCaptor;
@@ -51,6 +52,7 @@ public class BaseRobolectricTestApplication extends Application implements Expor
     private final MetricExporterCaptor metricExporter;
     private final List<Configuration> configurations = new ArrayList<>();
     private NtpManager ntpManager;
+    private SessionManager sessionManager;
     private CentralConfigurationInitializer centralConfigurationInitializer;
     private PersistenceInitializer persistenceInitializer;
 
@@ -107,6 +109,7 @@ public class BaseRobolectricTestApplication extends Application implements Expor
         setUpNtpManager();
         setUpCentralConfigurationInitializer();
         persistenceInitializer = mock(PersistenceInitializer.class);
+        sessionManager = mock(SessionManager.class);
     }
 
     private void setUpCentralConfigurationInitializer() {
@@ -167,6 +170,11 @@ public class BaseRobolectricTestApplication extends Application implements Expor
     @Override
     public NtpManager getNtpManager() {
         return ntpManager;
+    }
+
+    @Override
+    public SessionManager getSessionManager() {
+        return sessionManager;
     }
 
     @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 #Wed Aug 23 09:03:40 UTC 2023
 androidGradlePlugin_version=7.3.0
 description=APM for Android applications with the Elastic stack
-org.gradle.jvmargs=-XX\:MaxMetaspaceSize\=1G
+org.gradle.jvmargs=-XX\:MaxMetaspaceSize\=2G
 version=0.9.0
 android.useAndroidX=true
 group=co.elastic.apm


### PR DESCRIPTION
This is needed to later work on #177 

The session id is currently generated using an implementation of `SessionIdProvider` which is meant to be configurable. That causes issues when we later add the sampling logic, as it'd be only available for our session id provider implementation, making custom implementations to break the sampling functionality.

As part of these changes, the session id logic is moved to a new class, `SessionManager`, which is final and will handle the sampling logic too. Only the generation of an ID is now configurable through the `SessionIdGenerator` interface.