### PR TITLE
buildkite: pre-command failed when loading the pipeline

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -8,6 +8,11 @@
 
 set -eo pipefail
 
+if [[ "$BUILDKITE_COMMAND" =~ .*"upload".* ]]; then
+  echo "Skipped pre-command when running the Upload pipeline"
+  exit 0
+fi
+
 echo "--- Prepare vault context"
 set +x
 VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-apm-agent-android/internal-ci-approle)


### PR DESCRIPTION
Otherwise the `pre-command` will run for that particular dynamic pipeline creation and it's not required.
in addition since it runs in a k8s pod rather than in a `gcp` VM it will fail when installing the android since it uses `unzip`.


Already asked whether we can use something more elegant than using this conditional

<img width="881" alt="image" src="https://github.com/elastic/apm-agent-android/assets/2871786/a71410b2-f53d-4869-a20b-8634bebb5bfc">
