### PR TITLE
postRelease: tag releases with v<major>.<minor>.<patch>

### DIFF
--- a/build-tools/src/main/java/co/elastic/apm/compile/tools/publishing/tasks/PostDeployTask.java
+++ b/build-tools/src/main/java/co/elastic/apm/compile/tools/publishing/tasks/PostDeployTask.java
@@ -38,8 +38,9 @@ public class PostDeployTask extends DefaultTask {
         Properties properties = getProperties(gradlePropertiesFile);
 
         String currentVersion = properties.getProperty("version");
-        setGitTag(currentVersion);
-        setGitHubRelease(currentVersion);
+        String releaseTag = "v" + version;
+        setGitTag(releaseTag);
+        setGitHubRelease(version, releaseTag);
 
         String newVersion = VersionUtility.bumpMinorVersion(currentVersion);
 
@@ -58,13 +59,12 @@ public class PostDeployTask extends DefaultTask {
     }
 
     private void setGitTag(String version) {
-        log("Setting git tag to: v" + version);
-        runCommand("git tag v" + version);
+        log("Setting git tag to: " + version);
+        runCommand("git tag " + version);
         runCommand("git push --tags");
     }
 
-    private void setGitHubRelease(String version) {
-        String releaseTag = "v" + version;
+    private void setGitHubRelease(String version, String releaseTag) {
         log("Setting GitHub release to: " + releaseTag);
         String title = "Release " + version;
         String notes = "[Release Notes for " + version + "](https://www.elastic.co/guide/en/apm/agent/android/current/release-notes-0.x.html#release-notes-" + version + ")";

--- a/build-tools/src/main/java/co/elastic/apm/compile/tools/publishing/tasks/PostDeployTask.java
+++ b/build-tools/src/main/java/co/elastic/apm/compile/tools/publishing/tasks/PostDeployTask.java
@@ -39,6 +39,7 @@ public class PostDeployTask extends DefaultTask {
 
         String currentVersion = properties.getProperty("version");
         setGitTag(currentVersion);
+        setGitHubRelease(currentVersion);
 
         String newVersion = VersionUtility.bumpMinorVersion(currentVersion);
 
@@ -57,9 +58,17 @@ public class PostDeployTask extends DefaultTask {
     }
 
     private void setGitTag(String version) {
-        log("Setting git tag to: " + version);
-        runCommand("git tag " + version);
+        log("Setting git tag to: v" + version);
+        runCommand("git tag v" + version);
         runCommand("git push --tags");
+    }
+
+    private void setGitHubRelease(String version) {
+        String releaseTag = "v" + version;
+        log("Setting GitHub release to: " + releaseTag);
+        String title = "Release " + version;
+        String notes = "[Release Notes for " + version + "](https://www.elastic.co/guide/en/apm/agent/android/current/release-notes-0.x.html#release-notes-" + version + ")";
+        runCommand("gh release create " + releaseTag + " --title " + title + " --notes " + notes);
     }
 
     private void updateNextVersion(File gradlePropertiesFile, Properties properties, String newVersion) {

--- a/build-tools/src/main/java/co/elastic/apm/compile/tools/publishing/tasks/PostDeployTask.java
+++ b/build-tools/src/main/java/co/elastic/apm/compile/tools/publishing/tasks/PostDeployTask.java
@@ -38,9 +38,9 @@ public class PostDeployTask extends DefaultTask {
         Properties properties = getProperties(gradlePropertiesFile);
 
         String currentVersion = properties.getProperty("version");
-        String releaseTag = "v" + version;
+        String releaseTag = "v" + currentVersion;
         setGitTag(releaseTag);
-        setGitHubRelease(version, releaseTag);
+        setGitHubRelease(currentVersion, releaseTag);
 
         String newVersion = VersionUtility.bumpMinorVersion(currentVersion);
 


### PR DESCRIPTION
Create GitHub release using the `gh` cli.
Tag releases with `v<major>.<minor>.<patch>`
Add notes pointing out to https://www.elastic.co/guide/en/apm/agent/android/current/release-notes-0.x.html


Similarly done in https://github.com/elastic/apm-agent-java/releases/tag/v1.42.0
