### PR TITLE
release: debug the gpg secring

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -75,6 +75,9 @@ echo "$KEYPASS_SECRET" | gpg --batch --import "$KEY_FILE"
 export SECRING_FILE=$GNUPGHOME"/secring.gpg"
 gpg --pinentry-mode=loopback --passphrase "$KEYPASS_SECRET" --export-secret-key $KEY_ID_SECRET > "$SECRING_FILE"
 
+echo "--- Debug keys context :closed_lock_with_key:"
+ls -l "$SECRING_FILE"
+
 echo "--- Configure git context :git:"
 # Configure the committer since the maven release requires to push changes to GitHub
 # This will help with the SLSA requirements.

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -11,6 +11,9 @@
 
 set -e
 
+echo "--- Debug keys context :closed_lock_with_key:"
+ls -l "$SECRING_FILE"
+
 echo "--- Prepare release context"
 # Avoid detached HEAD since the release plugin requires to be on a branch
 git checkout -f "${branch_specifier}"


### PR DESCRIPTION
Print the file so we know it's available when running the release when preparing the environment and when running the release. 