### PR TITLE
Enhancing internal logging

### DIFF
--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/ElasticApmAgent.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/ElasticApmAgent.java
@@ -114,10 +114,10 @@ public final class ElasticApmAgent {
             throw new IllegalStateException("Already initialized");
         }
         Context appContext = context.getApplicationContext();
-        Elog.init(new AndroidLoggerFactory());
+        ElasticApmConfiguration finalConfiguration = (configuration == null) ? ElasticApmConfiguration.getDefault() : configuration;
+        Elog.init(new AndroidLoggerFactory(finalConfiguration.libraryLoggingPolicy));
         ServiceManager.initialize(appContext);
         ServiceManager.get().start();
-        ElasticApmConfiguration finalConfiguration = (configuration == null) ? ElasticApmConfiguration.getDefault() : configuration;
         Connectivity finalConnectivity = (connectivity == null) ? Connectivity.getDefault() : connectivity;
         AgentDependenciesInjector injector = process(new DefaultAgentDependenciesInjector(appContext, finalConfiguration, finalConnectivity), interceptor);
         instance = new ElasticApmAgent(finalConfiguration);

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/ElasticApmConfiguration.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/ElasticApmConfiguration.java
@@ -24,6 +24,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import co.elastic.apm.android.sdk.configuration.logging.LogLevel;
+import co.elastic.apm.android.sdk.configuration.logging.LoggingPolicy;
 import co.elastic.apm.android.sdk.connectivity.ExportProtocol;
 import co.elastic.apm.android.sdk.connectivity.opentelemetry.SignalConfiguration;
 import co.elastic.apm.android.sdk.features.persistence.PersistenceConfiguration;
@@ -49,6 +51,7 @@ public final class ElasticApmConfiguration {
     public final List<SpanFilter> spanFilters;
     public final List<LogFilter> logFilters;
     public final List<MetricFilter> metricFilters;
+    public final LoggingPolicy libraryLoggingPolicy;
 
     public static Builder builder() {
         return new Builder();
@@ -69,6 +72,7 @@ public final class ElasticApmConfiguration {
         persistenceConfiguration = builder.persistenceConfiguration;
         sampleRate = builder.sampleRate;
         exportProtocol = builder.exportProtocol;
+        libraryLoggingPolicy = builder.libraryLoggingPolicy;
         spanFilters = Collections.unmodifiableList(new ArrayList<>(builder.spanFilters));
         logFilters = Collections.unmodifiableList(new ArrayList<>(builder.logFilters));
         metricFilters = Collections.unmodifiableList(new ArrayList<>(builder.metricFilters));
@@ -85,6 +89,7 @@ public final class ElasticApmConfiguration {
         private SignalConfiguration signalConfiguration;
         private double sampleRate = 1.0;
         private ExportProtocol exportProtocol = ExportProtocol.GRPC;
+        private LoggingPolicy libraryLoggingPolicy = LoggingPolicy.getDefault();
         private final Set<SpanFilter> spanFilters = new HashSet<>();
         private final Set<LogFilter> logFilters = new HashSet<>();
         private final Set<MetricFilter> metricFilters = new HashSet<>();
@@ -188,6 +193,15 @@ public final class ElasticApmConfiguration {
          */
         public Builder setExportProtocol(ExportProtocol exportProtocol) {
             this.exportProtocol = exportProtocol;
+            return this;
+        }
+
+        /**
+         * Sets the logging policy for this library's internal logs. By default, it will log all the {@link LogLevel}s on debuggable applications
+         * and only logs from level INFO and above for non-debuggable applications.
+         */
+        public Builder setLibraryLoggingPolicy(LoggingPolicy libraryLoggingPolicy) {
+            this.libraryLoggingPolicy = libraryLoggingPolicy;
             return this;
         }
 

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/configuration/logging/LogLevel.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/configuration/logging/LogLevel.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.android.sdk.configuration.logging;
+
+public enum LogLevel {
+    TRACE(0), DEBUG(1), INFO(2), WARN(3), ERROR(4);
+
+    public final int value;
+
+    LogLevel(int value) {
+        this.value = value;
+    }
+}

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/configuration/logging/LoggingPolicy.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/configuration/logging/LoggingPolicy.java
@@ -37,13 +37,19 @@ public interface LoggingPolicy {
     }
 
     /**
-     * Convenience method for creating a static logging policy.
+     * Convenience method for creating an enabled logging policy with a static minimum level.
      *
-     * @param isEnabled    - Whether the logs are enabled or not.
      * @param minimumLevel - The minimum {@link LogLevel}, all the logs with this level and above will get printed, others will be ignored.
      */
-    static LoggingPolicy create(boolean isEnabled, LogLevel minimumLevel) {
-        return new SimpleLoggingPolicy(isEnabled, minimumLevel);
+    static LoggingPolicy enabled(LogLevel minimumLevel) {
+        return new SimpleLoggingPolicy(true, minimumLevel);
+    }
+
+    /**
+     * Convenience method for creating a policy that disables all internal logs.
+     */
+    static LoggingPolicy disabled() {
+        return new SimpleLoggingPolicy(false, LogLevel.TRACE);
     }
 
     /**

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/configuration/logging/LoggingPolicy.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/configuration/logging/LoggingPolicy.java
@@ -18,10 +18,33 @@
  */
 package co.elastic.apm.android.sdk.configuration.logging;
 
+import co.elastic.apm.android.sdk.configuration.logging.impl.DefaultLoggingPolicy;
+import co.elastic.apm.android.sdk.configuration.logging.impl.SimpleLoggingPolicy;
+
 /**
  * Defines the internal logging behavior of this library.
  */
 public interface LoggingPolicy {
+
+    /**
+     * Provides the default logging policy which will log all the {@link LogLevel}s on debuggable applications
+     * and only logs from level INFO and above for non-debuggable applications.
+     * <p>
+     * No logs will be created until the Agent is initialized.
+     */
+    static LoggingPolicy getDefault() {
+        return DefaultLoggingPolicy.create();
+    }
+
+    /**
+     * Convenience method for creating a static logging policy.
+     *
+     * @param isEnabled    - Whether the logs are enabled or not.
+     * @param minimumLevel - The minimum {@link LogLevel}, all the logs with this level and above will get printed, others will be ignored.
+     */
+    static LoggingPolicy create(boolean isEnabled, LogLevel minimumLevel) {
+        return new SimpleLoggingPolicy(isEnabled, minimumLevel);
+    }
 
     /**
      * Whether logging in general is enabled or not. This value will be checked before the log level.

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/configuration/logging/LoggingPolicy.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/configuration/logging/LoggingPolicy.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.android.sdk.configuration.logging;
+
+/**
+ * Defines the internal logging behavior of this library.
+ */
+public interface LoggingPolicy {
+
+    /**
+     * Whether logging in general is enabled or not. This value will be checked before the log level.
+     */
+    boolean isEnabled();
+
+    /**
+     * If logging is enabled, this value will be checked later to filter which logs will
+     * get printed. Logs with at least the level provided here or higher will pass, other ones (below the level provided here) will be ignored.
+     */
+    LogLevel getMinimumLevel();
+}

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/configuration/logging/impl/DefaultLoggingPolicy.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/configuration/logging/impl/DefaultLoggingPolicy.java
@@ -30,24 +30,27 @@ import co.elastic.apm.android.sdk.internal.utilities.providers.Provider;
 public class DefaultLoggingPolicy implements LoggingPolicy {
 
     private final Provider<Boolean> appIsDebuggable;
+    private final Provider<Boolean> agentIsInitialized;
 
     public static DefaultLoggingPolicy create() {
+        final Provider<Boolean> agentIsInitialized = ElasticApmAgent::isInitialized;
         return new DefaultLoggingPolicy(LazyProvider.of(() -> {
-            if (!ElasticApmAgent.isInitialized()) {
+            if (!agentIsInitialized.get()) {
                 return false;
             }
             AppInfoService service = ServiceManager.get().getService(Service.Names.APP_INFO);
             return service.isInDebugMode();
-        }));
+        }), agentIsInitialized);
     }
 
-    public DefaultLoggingPolicy(Provider<Boolean> appIsDebuggable) {
+    public DefaultLoggingPolicy(Provider<Boolean> appIsDebuggable, Provider<Boolean> agentIsInitialized) {
         this.appIsDebuggable = appIsDebuggable;
+        this.agentIsInitialized = agentIsInitialized;
     }
 
     @Override
     public boolean isEnabled() {
-        return true;
+        return agentIsInitialized.get();
     }
 
     @Override

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/configuration/logging/impl/DefaultLoggingPolicy.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/configuration/logging/impl/DefaultLoggingPolicy.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.android.sdk.configuration.logging.impl;
+
+import co.elastic.apm.android.sdk.ElasticApmAgent;
+import co.elastic.apm.android.sdk.configuration.logging.LogLevel;
+import co.elastic.apm.android.sdk.configuration.logging.LoggingPolicy;
+import co.elastic.apm.android.sdk.internal.services.Service;
+import co.elastic.apm.android.sdk.internal.services.ServiceManager;
+import co.elastic.apm.android.sdk.internal.services.appinfo.AppInfoService;
+import co.elastic.apm.android.sdk.internal.utilities.providers.LazyProvider;
+import co.elastic.apm.android.sdk.internal.utilities.providers.Provider;
+
+public class DefaultLoggingPolicy implements LoggingPolicy {
+
+    private final Provider<Boolean> appIsDebuggable;
+
+    public static DefaultLoggingPolicy create() {
+        return new DefaultLoggingPolicy(LazyProvider.of(() -> {
+            if (!ElasticApmAgent.isInitialized()) {
+                return false;
+            }
+            AppInfoService service = ServiceManager.get().getService(Service.Names.APP_INFO);
+            return service.isInDebugMode();
+        }));
+    }
+
+    public DefaultLoggingPolicy(Provider<Boolean> appIsDebuggable) {
+        this.appIsDebuggable = appIsDebuggable;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public LogLevel getMinimumLevel() {
+        return (appIsDebuggable.get()) ? LogLevel.DEBUG : LogLevel.INFO;
+    }
+}

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/configuration/logging/impl/SimpleLoggingPolicy.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/configuration/logging/impl/SimpleLoggingPolicy.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.android.sdk.configuration.logging.impl;
+
+import co.elastic.apm.android.sdk.configuration.logging.LogLevel;
+import co.elastic.apm.android.sdk.configuration.logging.LoggingPolicy;
+
+public final class SimpleLoggingPolicy implements LoggingPolicy {
+    private final boolean isEnabled;
+    private final LogLevel minimumLevel;
+
+    public SimpleLoggingPolicy(boolean isEnabled, LogLevel minimumLevel) {
+        this.isEnabled = isEnabled;
+        this.minimumLevel = minimumLevel;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return isEnabled;
+    }
+
+    @Override
+    public LogLevel getMinimumLevel() {
+        return minimumLevel;
+    }
+}

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/internal/features/contentprovider/ElasticInitializer.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/internal/features/contentprovider/ElasticInitializer.java
@@ -26,15 +26,12 @@ import android.net.Uri;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import co.elastic.apm.android.common.internal.logging.Elog;
 import co.elastic.apm.android.sdk.internal.features.launchtime.LaunchTimeTracker;
-import co.elastic.apm.android.sdk.internal.utilities.logging.AndroidLoggerFactory;
 
 public final class ElasticInitializer extends ContentProvider {
 
     @Override
     public boolean onCreate() {
-        Elog.init(new AndroidLoggerFactory());
         LaunchTimeTracker.startTimer();
         return true;
     }

--- a/android-sdk/src/main/java/co/elastic/apm/android/sdk/internal/utilities/logging/AndroidLoggerFactory.java
+++ b/android-sdk/src/main/java/co/elastic/apm/android/sdk/internal/utilities/logging/AndroidLoggerFactory.java
@@ -21,11 +21,17 @@ package co.elastic.apm.android.sdk.internal.utilities.logging;
 import org.slf4j.Logger;
 
 import co.elastic.apm.android.common.internal.logging.ELoggerFactory;
+import co.elastic.apm.android.sdk.configuration.logging.LoggingPolicy;
 
 public class AndroidLoggerFactory extends ELoggerFactory {
+    private final LoggingPolicy policy;
+
+    public AndroidLoggerFactory(LoggingPolicy policy) {
+        this.policy = policy;
+    }
 
     @Override
     public Logger getLogger(String name) {
-        return new AndroidLogger(name);
+        return new AndroidLogger(name, policy);
     }
 }

--- a/android-sdk/src/test/java/co/elastic/apm/android/sdk/configuration/logging/impl/DefaultLoggingPolicyTest.java
+++ b/android-sdk/src/test/java/co/elastic/apm/android/sdk/configuration/logging/impl/DefaultLoggingPolicyTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.android.sdk.configuration.logging.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import co.elastic.apm.android.sdk.configuration.logging.LogLevel;
+import co.elastic.apm.android.sdk.testutils.providers.SimpleProvider;
+
+public class DefaultLoggingPolicyTest {
+
+    @Test
+    public void isEnabled_returnTrue() {
+        assertTrue(getInstance(true).isEnabled());
+        assertTrue(getInstance(false).isEnabled());
+    }
+
+    @Test
+    public void getMinimumLevel_onDebuggableApp() {
+        assertEquals(LogLevel.DEBUG, getInstance(true).getMinimumLevel());
+    }
+
+    @Test
+    public void getMinimumLevel_onNonDebuggableApp() {
+        assertEquals(LogLevel.INFO, getInstance(false).getMinimumLevel());
+    }
+
+    private static DefaultLoggingPolicy getInstance(boolean appIsDebuggable) {
+        return new DefaultLoggingPolicy(SimpleProvider.create(appIsDebuggable));
+    }
+}

--- a/android-sdk/src/test/java/co/elastic/apm/android/sdk/configuration/logging/impl/DefaultLoggingPolicyTest.java
+++ b/android-sdk/src/test/java/co/elastic/apm/android/sdk/configuration/logging/impl/DefaultLoggingPolicyTest.java
@@ -19,6 +19,7 @@
 package co.elastic.apm.android.sdk.configuration.logging.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -29,9 +30,15 @@ import co.elastic.apm.android.sdk.testutils.providers.SimpleProvider;
 public class DefaultLoggingPolicyTest {
 
     @Test
-    public void isEnabled_returnTrue() {
+    public void isEnabled_true_whenAgentIsInitialized() {
         assertTrue(getInstance(true).isEnabled());
         assertTrue(getInstance(false).isEnabled());
+    }
+
+    @Test
+    public void isEnabled_false_whenAgentNotInitialized() {
+        assertFalse(getInstance(true, false).isEnabled());
+        assertFalse(getInstance(false, false).isEnabled());
     }
 
     @Test
@@ -45,6 +52,10 @@ public class DefaultLoggingPolicyTest {
     }
 
     private static DefaultLoggingPolicy getInstance(boolean appIsDebuggable) {
-        return new DefaultLoggingPolicy(SimpleProvider.create(appIsDebuggable));
+        return getInstance(appIsDebuggable, true);
+    }
+
+    private static DefaultLoggingPolicy getInstance(boolean appIsDebuggable, boolean agentIsInitialized) {
+        return new DefaultLoggingPolicy(SimpleProvider.create(appIsDebuggable), SimpleProvider.create(agentIsInitialized));
     }
 }

--- a/android-sdk/src/test/java/co/elastic/apm/android/sdk/configuration/logging/impl/SimpleLoggingPolicyTest.java
+++ b/android-sdk/src/test/java/co/elastic/apm/android/sdk/configuration/logging/impl/SimpleLoggingPolicyTest.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.android.sdk.configuration.logging.impl;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import co.elastic.apm.android.sdk.configuration.logging.LogLevel;
+import co.elastic.apm.android.sdk.configuration.logging.LoggingPolicy;
+
+public class SimpleLoggingPolicyTest {
+
+    @Test
+    public void verifyProvidedValues() {
+        LoggingPolicy policy = new SimpleLoggingPolicy(true, LogLevel.INFO);
+        LoggingPolicy policy2 = new SimpleLoggingPolicy(false, LogLevel.ERROR);
+
+        assertTrue(policy.isEnabled());
+        assertEquals(LogLevel.INFO, policy.getMinimumLevel());
+        assertFalse(policy2.isEnabled());
+        assertEquals(LogLevel.ERROR, policy2.getMinimumLevel());
+    }
+}

--- a/android-sdk/src/test/java/co/elastic/apm/android/sdk/internal/utilities/logging/AndroidLoggerTest.java
+++ b/android-sdk/src/test/java/co/elastic/apm/android/sdk/internal/utilities/logging/AndroidLoggerTest.java
@@ -95,10 +95,10 @@ public class AndroidLoggerTest {
     }
 
     private AndroidLogger getLogger(LogLevel minimumLevel) {
-        return new AndroidLogger("TAG", LoggingPolicy.create(true, minimumLevel));
+        return new AndroidLogger("TAG", LoggingPolicy.enabled(minimumLevel));
     }
 
     private AndroidLogger getLoggerWithDisabledPolicy() {
-        return new AndroidLogger("TAG", LoggingPolicy.create(false, LogLevel.TRACE));
+        return new AndroidLogger("TAG", LoggingPolicy.disabled());
     }
 }

--- a/android-sdk/src/test/java/co/elastic/apm/android/sdk/internal/utilities/logging/AndroidLoggerTest.java
+++ b/android-sdk/src/test/java/co/elastic/apm/android/sdk/internal/utilities/logging/AndroidLoggerTest.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *	http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package co.elastic.apm.android.sdk.internal.utilities.logging;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import co.elastic.apm.android.sdk.configuration.logging.LogLevel;
+import co.elastic.apm.android.sdk.configuration.logging.LoggingPolicy;
+
+public class AndroidLoggerTest {
+
+    @Test
+    public void checkTraceLogger() {
+        AndroidLogger logger = getLogger(LogLevel.TRACE);
+
+        assertTrue(logger.isTraceEnabled());
+        assertTrue(logger.isDebugEnabled());
+        assertTrue(logger.isInfoEnabled());
+        assertTrue(logger.isWarnEnabled());
+        assertTrue(logger.isErrorEnabled());
+    }
+
+    @Test
+    public void checkDebugLogger() {
+        AndroidLogger logger = getLogger(LogLevel.DEBUG);
+
+        assertFalse(logger.isTraceEnabled());
+        assertTrue(logger.isDebugEnabled());
+        assertTrue(logger.isInfoEnabled());
+        assertTrue(logger.isWarnEnabled());
+        assertTrue(logger.isErrorEnabled());
+    }
+
+    @Test
+    public void checkInfoLogger() {
+        AndroidLogger logger = getLogger(LogLevel.INFO);
+
+        assertFalse(logger.isTraceEnabled());
+        assertFalse(logger.isDebugEnabled());
+        assertTrue(logger.isInfoEnabled());
+        assertTrue(logger.isWarnEnabled());
+        assertTrue(logger.isErrorEnabled());
+    }
+
+    @Test
+    public void checkWarnLogger() {
+        AndroidLogger logger = getLogger(LogLevel.WARN);
+
+        assertFalse(logger.isTraceEnabled());
+        assertFalse(logger.isDebugEnabled());
+        assertFalse(logger.isInfoEnabled());
+        assertTrue(logger.isWarnEnabled());
+        assertTrue(logger.isErrorEnabled());
+    }
+
+    @Test
+    public void checkErrorLogger() {
+        AndroidLogger logger = getLogger(LogLevel.ERROR);
+
+        assertFalse(logger.isTraceEnabled());
+        assertFalse(logger.isDebugEnabled());
+        assertFalse(logger.isInfoEnabled());
+        assertFalse(logger.isWarnEnabled());
+        assertTrue(logger.isErrorEnabled());
+    }
+
+    @Test
+    public void checkDisabledPolicy() {
+        AndroidLogger logger = getLoggerWithDisabledPolicy();
+
+        assertFalse(logger.isTraceEnabled());
+        assertFalse(logger.isDebugEnabled());
+        assertFalse(logger.isInfoEnabled());
+        assertFalse(logger.isWarnEnabled());
+        assertFalse(logger.isErrorEnabled());
+    }
+
+    private AndroidLogger getLogger(LogLevel minimumLevel) {
+        return new AndroidLogger("TAG", LoggingPolicy.create(true, minimumLevel));
+    }
+
+    private AndroidLogger getLoggerWithDisabledPolicy() {
+        return new AndroidLogger("TAG", LoggingPolicy.create(false, LogLevel.TRACE));
+    }
+}

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -388,12 +388,12 @@ This table outlines the attributes and their corresponding permissions:
 |===
 
 [float]
-==== Configuring this library's logging policy
+==== Logging policy
 
-By default, this library's internal logs are all printed for a debuggable app build.
-In the case of non-debuggable builds, only logs starting from level INFO onwards are printed.
+By default, all logs created by this library are printed for a debuggable app build.
+In the case of non-debuggable builds, only logs at the INFO level and above are printed.
 
-In case you would like to have a more customized policy, or even disable all of the logs from this library altogether, you could do so by providing your own `LoggingPolicy` config like so:
+If you would like to create a custom log policy or even disable all of the logs from this library altogether, you can do so by providing your own `LoggingPolicy` configuration. The below example policy will allow all logs of level WARN and higher to be printed. Levels below WARN will be ignored.
 
 [source,java]
 ----

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -388,6 +388,32 @@ This table outlines the attributes and their corresponding permissions:
 |===
 
 [float]
+==== Configuring this library's logging policy
+
+By default, this library's internal logs are all printed for a debuggable app build.
+In the case of non-debuggable builds, only logs starting from level INFO onwards are printed.
+
+In case you would like to have a more customized policy, or even disable all of the logs from this library altogether, you could do so by providing your own `LoggingPolicy` config like so:
+
+[source,java]
+----
+class MyApp extends android.app.Application {
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        // This example policy will allow all logs of level WARN and higher to get printed, ignoring levels below it.
+        LoggingPolicy loggingPolicy = LoggingPolicy.enabled(LogLevel.WARN);
+
+        ElasticApmConfiguration.builder()
+                .setLibraryLoggingPolicy(loggingPolicy)
+                .build();
+        ElasticApmAgent.initialize(this, configuration);
+    }
+}
+----
+
+[float]
 === Advanced configurable options
 
 [float]

--- a/docs/configuration.asciidoc
+++ b/docs/configuration.asciidoc
@@ -388,7 +388,7 @@ This table outlines the attributes and their corresponding permissions:
 |===
 
 [float]
-==== Logging policy
+==== Internal logging policy
 
 By default, all logs created by this library are printed for a debuggable app build.
 In the case of non-debuggable builds, only logs at the INFO level and above are printed.


### PR DESCRIPTION
Closes #243 

This PR:

* Disables internal logs for when the Agent is not initialized.
* Provides configuration for customizing the overall internal logs behavior.