### PR TITLE
ci(release): use new set of credentials for GPG and Maven Central

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -1,12 +1,19 @@
 # Buildkite
 
-This README provides an overview of the Buildkite pipeline used to automate the build and publishing process.
+This README provides an overview of the Buildkite pipeline to automate the build and publishing process.
 
 ## Release pipeline
 
-This is the Buildkite pipeline for releasing the APM Agent android.
+The Buildkite pipeline for the APM Agent Android is responsible for the releases.
 
 ### Pipeline Configuration
 
 To view the pipeline and its configuration, click [here](https://buildkite.com/elastic/apm-agent-android-release) or
 go to the definition in the `elastic/ci` repository.
+
+### Credentials
+
+The release team provides the credentials to publish the artifacts in Maven Central/Gradle Plugin and sign them
+with the GPG.
+
+If further details are needed, please go to [pre-command](hooks/pre-command).

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -15,6 +15,7 @@ fi
 
 echo "--- Prepare vault context"
 set +x
+# TODO: this should be removed.
 VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-apm-agent-android/internal-ci-approle)
 export VAULT_ROLE_ID_SECRET
 VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-apm-agent-android/internal-ci-approle)
@@ -44,28 +45,36 @@ clean_up () {
 }
 trap clean_up EXIT
 
-echo "--- Prepare keys context"
+echo "--- Prepare keys context :key:"
 set +x
-VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID_SECRET" secret_id="$VAULT_SECRET_ID_SECRET")
-export VAULT_TOKEN
 # Nexus credentials (they cannot use the _SECRET pattern since they are in-memory based)
 # See https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
-ORG_GRADLE_PROJECT_sonatypeUsername=$(vault read -field=username secret/release/nexus)
+NEXUS_SECRET=kv/ci-shared/release-eng/team-release-secrets/apm/maven_central
+ORG_GRADLE_PROJECT_sonatypeUsername=$(vault read -field username $NEXUS_SECRET)
 export ORG_GRADLE_PROJECT_sonatypeUsername
-ORG_GRADLE_PROJECT_sonatypePassword=$(vault read -field=password secret/release/nexus)
+ORG_GRADLE_PROJECT_sonatypePassword=$(vault read -field password $NEXUS_SECRET)
 export ORG_GRADLE_PROJECT_sonatypePassword
 
+# Signing keys
+GPG_SECRET=kv/data/ci-shared/release-eng/team-release-secrets/apm/gpg
+vault read -field="keyring" $GPG_SECRET | base64 -d > $KEY_FILE
+## NOTE: passphase is the name of the field.
+KEYPASS_SECRET=$(vault read -field="passphase" $GPG_SECRET)
+export KEYPASS_SECRET
+KEY_ID=$(vault kv get --field="key_id" $GPG_SECRET)
+KEY_ID_SECRET=${KEY_ID: -8}
+export KEY_ID_SECRET
+
+# TODO: this should be removed.
+VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID_SECRET" secret_id="$VAULT_SECRET_ID_SECRET")
+export VAULT_TOKEN
+
+# TODO: this should be changed with the new vault secrets.
 # Gradle Plugin portal credentials
 PLUGIN_PORTAL_KEY=$(vault read secret/release/gradle-plugin-portal -format=json  | jq -r .data.key)
 export PLUGIN_PORTAL_KEY
 PLUGIN_PORTAL_SECRET=$(vault read secret/release/gradle-plugin-portal -format=json  | jq -r .data.secret)
 export PLUGIN_PORTAL_SECRET
-
-# Signing keys
-vault read -field=key secret/release/signing >$KEY_FILE
-KEYPASS_SECRET=$(vault read -field=passphrase secret/release/signing)
-export KEYPASS_SECRET
-unset VAULT_TOKEN
 
 # Import the key into the keyring
 echo "$KEYPASS_SECRET" | gpg --batch --import "$KEY_FILE"

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -56,7 +56,7 @@ ORG_GRADLE_PROJECT_sonatypePassword=$(vault kv get --field="password" $NEXUS_SEC
 export ORG_GRADLE_PROJECT_sonatypePassword
 
 # Signing keys
-GPG_SECRET=kv/data/ci-shared/release-eng/team-release-secrets/apm/gpg
+GPG_SECRET=kv/ci-shared/release-eng/team-release-secrets/apm/gpg
 vault kv get --field="keyring" $GPG_SECRET | base64 -d > $KEY_FILE
 ## NOTE: passphase is the name of the field.
 KEYPASS_SECRET=$(vault kv get --field="passphase" $GPG_SECRET)

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -50,16 +50,16 @@ set +x
 # Nexus credentials (they cannot use the _SECRET pattern since they are in-memory based)
 # See https://docs.gradle.org/current/userguide/signing_plugin.html#sec:in-memory-keys
 NEXUS_SECRET=kv/ci-shared/release-eng/team-release-secrets/apm/maven_central
-ORG_GRADLE_PROJECT_sonatypeUsername=$(vault read -field username $NEXUS_SECRET)
+ORG_GRADLE_PROJECT_sonatypeUsername=$(vault kv get --field="username" $NEXUS_SECRET)
 export ORG_GRADLE_PROJECT_sonatypeUsername
-ORG_GRADLE_PROJECT_sonatypePassword=$(vault read -field password $NEXUS_SECRET)
+ORG_GRADLE_PROJECT_sonatypePassword=$(vault kv get --field="password" $NEXUS_SECRET)
 export ORG_GRADLE_PROJECT_sonatypePassword
 
 # Signing keys
 GPG_SECRET=kv/data/ci-shared/release-eng/team-release-secrets/apm/gpg
 vault read -field="keyring" $GPG_SECRET | base64 -d > $KEY_FILE
 ## NOTE: passphase is the name of the field.
-KEYPASS_SECRET=$(vault read -field="passphase" $GPG_SECRET)
+KEYPASS_SECRET=$(vault kv get --field="passphase" $GPG_SECRET)
 export KEYPASS_SECRET
 KEY_ID=$(vault kv get --field="key_id" $GPG_SECRET)
 KEY_ID_SECRET=${KEY_ID: -8}

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -57,7 +57,7 @@ export ORG_GRADLE_PROJECT_sonatypePassword
 
 # Signing keys
 GPG_SECRET=kv/data/ci-shared/release-eng/team-release-secrets/apm/gpg
-vault read -field="keyring" $GPG_SECRET | base64 -d > $KEY_FILE
+vault kv get --field="keyring" $GPG_SECRET | base64 -d > $KEY_FILE
 ## NOTE: passphase is the name of the field.
 KEYPASS_SECRET=$(vault kv get --field="passphase" $GPG_SECRET)
 export KEYPASS_SECRET


### PR DESCRIPTION
### What

Use the Vault secrets accessed to run the Release/Snapshots.

Those secrets are managed by the Release team and they provided specific ones for this project.

### Why

The release team requested to use them.


### Steps

There is a missing thing to be done regarding the gradle plugin, to be done as soon as credentials are available in Vault.