### PR TITLE
ci(buildkite): vault context switch

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -20,12 +20,10 @@ VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-apm-agent-and
 export VAULT_ROLE_ID_SECRET
 VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-apm-agent-android/internal-ci-approle)
 export VAULT_SECRET_ID_SECRET
-VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-apm-agent-android/internal-ci-approle)
-export VAULT_ADDR
+PROD_VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-apm-agent-android/internal-ci-approle)
 
 # Delete the vault specific accessing the ci vault
 export VAULT_TOKEN_PREVIOUS=$VAULT_TOKEN
-unset VAULT_TOKEN
 
 echo "--- Prepare a secure temp :closed_lock_with_key:"
 # Prepare a secure temp folder not shared between other jobs to store the key ring
@@ -65,15 +63,20 @@ KEY_ID=$(vault kv get --field="key_id" $GPG_SECRET)
 KEY_ID_SECRET=${KEY_ID: -8}
 export KEY_ID_SECRET
 
-# TODO: this should be removed.
+# TODO: BEGIN - this should be removed.
+VAULT_ADDR=$PROD_VAULT_ADDR
+unset VAULT_TOKEN
+export VAULT_ADDR
 VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID_SECRET" secret_id="$VAULT_SECRET_ID_SECRET")
 export VAULT_TOKEN
+# END - this should be removed.
 
 # TODO: this should be changed with the new vault secrets.
 # Gradle Plugin portal credentials
-PLUGIN_PORTAL_KEY=$(vault read secret/release/gradle-plugin-portal -format=json  | jq -r .data.key)
+GRADLE_SECRET=secret/release/gradle-plugin-portal
+PLUGIN_PORTAL_KEY=$(vault read $GRADLE_SECRET -format=json  | jq -r .data.key)
 export PLUGIN_PORTAL_KEY
-PLUGIN_PORTAL_SECRET=$(vault read secret/release/gradle-plugin-portal -format=json  | jq -r .data.secret)
+PLUGIN_PORTAL_SECRET=$(vault read $GRADLE_SECRET -format=json  | jq -r .data.secret)
 export PLUGIN_PORTAL_SECRET
 
 # Import the key into the keyring


### PR DESCRIPTION
Fixes the context switch, otherwise, it's trying to access `vault-ci` secrets when the vault-address points to `vault-prod`


```
Error making API request.
--
  |  
  | URL: GET https://****:8200/v1/sys/internal/ui/mounts/kv/ci-shared/release-eng/team-release-secrets/apm/maven_central
  | Code: 403. Errors:

```