### PR TITLE
ci(release): use the new vault secret path

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -13,18 +13,6 @@ if [[ "$BUILDKITE_COMMAND" =~ .*"upload".* ]]; then
   exit 0
 fi
 
-echo "--- Prepare vault context"
-set +x
-# TODO: this should be removed.
-VAULT_ROLE_ID_SECRET=$(vault read -field=role-id secret/ci/elastic-apm-agent-android/internal-ci-approle)
-export VAULT_ROLE_ID_SECRET
-VAULT_SECRET_ID_SECRET=$(vault read -field=secret-id secret/ci/elastic-apm-agent-android/internal-ci-approle)
-export VAULT_SECRET_ID_SECRET
-PROD_VAULT_ADDR=$(vault read -field=vault-url secret/ci/elastic-apm-agent-android/internal-ci-approle)
-
-# Delete the vault specific accessing the ci vault
-export VAULT_TOKEN_PREVIOUS=$VAULT_TOKEN
-
 echo "--- Prepare a secure temp :closed_lock_with_key:"
 # Prepare a secure temp folder not shared between other jobs to store the key ring
 export TMP_WORKSPACE=/tmp/secured
@@ -36,7 +24,6 @@ chmod -R 700 $TMP_WORKSPACE
 # Make sure we delete this folder before leaving even in case of failure
 clean_up () {
   ARG=$?
-  export VAULT_TOKEN=$VAULT_TOKEN_PREVIOUS
   echo "--- Deleting tmp workspace"
   rm -rf $TMP_WORKSPACE
   exit $ARG
@@ -53,6 +40,13 @@ export ORG_GRADLE_PROJECT_sonatypeUsername
 ORG_GRADLE_PROJECT_sonatypePassword=$(vault kv get --field="password" $NEXUS_SECRET)
 export ORG_GRADLE_PROJECT_sonatypePassword
 
+# Gradle Plugin portal credentials
+GRADLE_SECRET=kv/ci-shared/release-eng/team-release-secrets/apm/gradle_plugin_portal
+PLUGIN_PORTAL_KEY=$(vault kv get --field="key" $GRADLE_SECRET)
+export PLUGIN_PORTAL_KEY
+PLUGIN_PORTAL_SECRET=$(vault kv get --field="secret" $GRADLE_SECRET -format=json)
+export PLUGIN_PORTAL_SECRET
+
 # Signing keys
 GPG_SECRET=kv/ci-shared/release-eng/team-release-secrets/apm/gpg
 vault kv get --field="keyring" $GPG_SECRET | base64 -d > $KEY_FILE
@@ -62,22 +56,6 @@ export KEYPASS_SECRET
 KEY_ID=$(vault kv get --field="key_id" $GPG_SECRET)
 KEY_ID_SECRET=${KEY_ID: -8}
 export KEY_ID_SECRET
-
-# TODO: BEGIN - this should be removed.
-VAULT_ADDR=$PROD_VAULT_ADDR
-unset VAULT_TOKEN
-export VAULT_ADDR
-VAULT_TOKEN=$(vault write -field=token auth/approle/login role_id="$VAULT_ROLE_ID_SECRET" secret_id="$VAULT_SECRET_ID_SECRET")
-export VAULT_TOKEN
-# END - this should be removed.
-
-# TODO: this should be changed with the new vault secrets.
-# Gradle Plugin portal credentials
-GRADLE_SECRET=secret/release/gradle-plugin-portal
-PLUGIN_PORTAL_KEY=$(vault read $GRADLE_SECRET -format=json  | jq -r .data.key)
-export PLUGIN_PORTAL_KEY
-PLUGIN_PORTAL_SECRET=$(vault read $GRADLE_SECRET -format=json  | jq -r .data.secret)
-export PLUGIN_PORTAL_SECRET
 
 # Import the key into the keyring
 echo "$KEYPASS_SECRET" | gpg --batch --import "$KEY_FILE"


### PR DESCRIPTION
this won't require the vault switch context

https://github.com/elastic/apm-agent-android/pull/255 talked the Maven Central and GPG