### PR TITLE
backstage: add tags for the obltmachine/apmmachine and other things

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -47,7 +47,6 @@ metadata:
     github.com/team-slug: elastic/apm-agent-android
   tags:
     - github
-    - github-action
     - gpg-sign
     - gradle-portal
     - maven-central
@@ -58,8 +57,10 @@ metadata:
     - title: GitHub action
       url: https://github.com/elastic/apm-agent-android/actions/workflows/release.yml
 spec:
-  type: service
+  type: github-actions
   owner: group:apm-agent-android
   lifecycle: production
   dependsOn:
     - "system:github-actions"
+    - "resource:user-apmmachine"
+    - "resource:user-obltmachine"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,6 +4,13 @@ apiVersion: backstage.io/v1alpha1
 kind: Resource
 metadata:
   name: buildkite-pipeline-apm-agent-android-release
+  tags:
+    - buildkite
+    - gpg-sign
+    - gradle-portal
+    - maven-central
+    - release
+    - user:apmmachine
 spec:
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -24,3 +31,35 @@ spec:
         observablt-robots-automation: {}
   owner: group:observablt-robots
   type: buildkite-pipeline
+
+---
+# A Component for the release GitHub action
+#
+# yaml-language-server: $schema=https://json.schemastore.org/catalog-info.json
+apiVersion: backstage.io/v1alpha1
+kind: Resource
+metadata:
+  name: apm-agent-android-release
+  description: GitHub action to run the release process for the APM Agent Android
+  annotations:
+    backstage.io/source-location: url:https://github.com/elastic/apm-agent-android/blob/main/.github/workflows/release.yml
+    github.com/project-slug: elastic/apm-agent-android
+    github.com/team-slug: elastic/apm-agent-android
+  tags:
+    - github
+    - github-action
+    - gpg-sign
+    - gradle-portal
+    - maven-central
+    - release
+    - user:apmmachine
+    - user:obltmachine
+  links:
+    - title: GitHub action
+      url: https://github.com/elastic/apm-agent-android/actions/workflows/release.yml
+spec:
+  type: service
+  owner: group:apm-agent-android
+  lifecycle: production
+  dependsOn:
+    - "system:github-actions"

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -62,5 +62,5 @@ spec:
   lifecycle: production
   dependsOn:
     - "system:github-actions"
-    - "resource:user-apmmachine"
-    - "resource:user-obltmachine"
+    - "user:apmmachine"
+    - "user:obltmachine"


### PR DESCRIPTION
Document the GitHub actions and Buildkite pipelines that use the Service machine accounts and other bits and pieces such as gpg-sing or maven central.

This should help with searching the dependencies easily in Backstage.