### PR TITLE
security: add permissions block to workflows

### DIFF
--- a/.github/workflows/addToProject.yml
+++ b/.github/workflows/addToProject.yml
@@ -6,6 +6,9 @@ on:
 env:
   MY_GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
 
+permissions:
+  contents: read
+
 jobs:
   assign_one_project:
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,9 @@ on:
     types: [opened]
 env:
   MY_GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
+permissions:
+  contents: read
+
 jobs:
   triage:
     runs-on: ubuntu-latest

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -8,6 +8,8 @@ env:
   MY_GITHUB_TOKEN: ${{ secrets.APM_TECH_USER_TOKEN }}
 permissions:
   contents: read
+  issues: write
+  pull-requests: write
 
 jobs:
   triage:

--- a/.github/workflows/opentelemetry.yml
+++ b/.github/workflows/opentelemetry.yml
@@ -10,6 +10,9 @@ on:
       - test-reporter
     types: [completed]
 
+permissions:
+  contents: read
+
 jobs:
   otel-export-trace:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -10,6 +10,10 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   report:
     runs-on: ubuntu-latest

--- a/.github/workflows/test-reporter.yml
+++ b/.github/workflows/test-reporter.yml
@@ -13,6 +13,7 @@ on:
 permissions:
   contents: read
   actions: read
+  checks: write
 
 jobs:
   report:


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

We want to set the default permissions for workflows to read-only for contents. 
This is a security measure to prevent accidental changes to the repository.

This change adds a top-level permissions block to all workflows in the .github/workflows directory.
```yaml
permissions:
  contents: read
```

In some cases workflows might need more permissions than just `contents: read`.
Please checkout this branch and add the necessary permissions to the workflows.

If your workflow uses a Personal Access Token (PAT), we can still add the permissions block,
   but it will not have any effect.

Merging this PR as is might cause workflows that need more permissions to fail.

If there are any questions, please reach out to the @elastic/observablt-ci
