### PR TITLE
Resolving main to release-branch conflicts before creating PR from main

### DIFF
--- a/.github/workflows/updateVersionBranch.yml
+++ b/.github/workflows/updateVersionBranch.yml
@@ -34,7 +34,13 @@ jobs:
           text: ${{ github.event.pull_request.head.ref }}
           regex: 'post-release/(\d+).+'
 
-      - run: gh pr create --base ${{ env.BASE_BRANCH }} --title 'Merge main into version branch' --body 'Created by Github action' --reviewer elastic/apm-agent-android
+      - run: |
+          CONFLICT_RESOLUTION_BRANCH="post-release/main-to-${{ env.BASE_BRANCH }}"
+          git switch ${{ env.BASE_BRANCH }}
+          git checkout -b $CONFLICT_RESOLUTION_BRANCH
+          git merge main --strategy-option theirs
+          git push -u origin $CONFLICT_RESOLUTION_BRANCH
+          gh pr create --base ${{ env.BASE_BRANCH }} --title 'Merge main into version branch' --body 'Created by Github action :robot:' --reviewer elastic/apm-agent-android
         env:
           GH_TOKEN: ${{ env.GITHUB_TOKEN }}
           BASE_BRANCH: "${{ steps.major-version.outputs.group1 }}.x"


### PR DESCRIPTION
For some reason, Github seems to believe that the branch `0.x` has conflicts with `main` whenever a new release is done. It also seems to believe that the 2 branches have more differences than they actually do, I guess that this was all caused by the `squash-merge` strategy we've used in the past to update the branch `0.x` with the latest changes from `main`, which causes Github to not find matching commits between the 2 branches.

This situation causes that any PR from `main` to `0.x` shows conflicts with the commonly changed files, such as CHANGELOG.asciidoc for example. 

These changes aim to resolve this conflict in a third branch (named `post-release/main-to-0.x`) before creating a PR to update `0.x` with the latest changes from `main`.