### PR TITLE
github-action: add attestations scope

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request'
     permissions:
+      attestations: write
       contents: write
       id-token: write
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
     env:
       TARBALL_FILE: dist.tar
     permissions:
+      attestations: write
       contents: write
       id-token: write
     steps:


### PR DESCRIPTION
> The attestations permission is necessary to persist the attestation.

As per [docs](https://github.com/github-early-access/generate-build-provenance?tab=readme-ov-file#usage)
