### PR TITLE
Revert "Bump actions/download-artifact from 3 to 4 in the github-actions group"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
             dry_run=true
             TARBALL_FILE=${{ env.TARBALL_FILE }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: signed-artifacts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,7 +77,7 @@ jobs:
             dry_run=${{ inputs.dry_run || 'false' }}
             TARBALL_FILE=${{ env.TARBALL_FILE }}
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v3
         with:
           name: signed-artifacts
 


### PR DESCRIPTION
Reverts elastic/apm-agent-android#306

I'm afraid this won't work. There is a dependency with https://github.com/elastic/apm-pipeline-library/blob/4302d6f846cce0c85199d5afa192a1e791a52d99/.github/actions/buildkite/action.yml#L110-L115

We have a plan to support `v4`

Sorry about this unclear dependency 