### PR TITLE
github-action: use setup composite action for jdk conf

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,27 @@
+---
+
+name: common build tasks
+description: Install specific JDK
+
+inputs:
+  java-version:
+    description: 'Testing Java version'
+    required: true
+    default: '17'
+  java-distribution:
+    description: 'Testing Java distribution'
+    required: true
+    default: 'temurin'
+  shell:
+    description: 'Default shell'
+    default: 'bash'
+    required: false
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up testing JDK
+      uses: actions/setup-java@v4
+      with:
+        java-version: ${{ inputs.java-version }}
+        distribution: ${{ inputs.java-distribution }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
 
@@ -10,6 +11,20 @@ updates:
       interval: "weekly"
       day: "sunday"
       time: "22:00"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  # GitHub composite actions
+  - package-ecosystem: "github-actions"
+    directory: "/.github/actions/setup"
+    schedule:
+      interval: "weekly"
+      day: "sunday"
+      time: "22:00"
+    reviewers:
+      - "elastic/observablt-ci"
     groups:
       github-actions:
         patterns:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
       - name: lint
         run: ./gradlew lint
       - name: Verify OSS compliance
@@ -31,6 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
       - name: Build
         run: ./gradlew assemble
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,6 +135,6 @@ jobs:
         with:
           ref: ${{ inputs.branch_specifier || 'main' }}
           token: ${{ env.GITHUB_TOKEN }}
-
+      - uses: ./.github/actions/setup
       - if: ${{ ! inputs.dry_run }}
         run: ./gradlew postDeploy -Prelease=true -Pversion_override=${{ inputs.version_override_specifier || '' }}

--- a/.github/workflows/snapshoty.yml
+++ b/.github/workflows/snapshoty.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
       - name: Assemble
         run: ./gradlew assemble
       - name: Publish snaphosts


### PR DESCRIPTION
Centralise the jdk installation in a composite reusable GitHub action called `.github/actions/setup`
