### PR TITLE
github-actions: run buildkite using GitHub secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
       - uses: elastic/oblt-actions/buildkite/download-artifact@v1.5.0
         with:
-          build-number: ${{ steps.buildkite-run.outputs.build }}
+          build-number: ${{ steps.buildkite-run.outputs.number }}
           path: ${{ env.TARBALL_FILE }}
           pipeline: ${{ steps.buildkite-run.outputs.pipeline }}
           token: ${{ secrets.BUILDKITE_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,15 @@ jobs:
 
   test-release:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request'
+    # If no PR event or if a PR event that's caused by a non-fork and non dependabot actor
+    if: |
+      ( github.event_name != 'pull_request'
+        ||
+        ( github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.fork == false &&
+          github.actor != 'dependabot[bot]'
+        )
+      )
     permissions:
       attestations: write
       contents: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,28 +71,26 @@ jobs:
     env:
       TARBALL_FILE: dist.tar
     steps:
-      - id: buildkite
+      - id: buildkite-run
         name: Run Release dry-run
-        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+        uses: elastic/oblt-actions/buildkite/run@v1.5.0
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: apm-agent-android-release
-          pipelineBranch: ${{ github.ref_name }}
-          waitFor: true
-          printBuildLogs: false
-          artifactName: signed-artifacts
-          artifactPath: ${{ env.TARBALL_FILE }}
-          buildEnvVars: |
+          branch: ${{ github.ref_name }}
+          pipeline: "apm-agent-android-release"
+          token: ${{ secrets.BUILDKITE_TOKEN }}
+          wait-for: true
+          env-vars: |
             branch_specifier=${{ github.ref_name }}
             target_specifier=all
             dry_run=true
             TARBALL_FILE=${{ env.TARBALL_FILE }}
 
-      - uses: actions/download-artifact@v3
+      - uses: elastic/oblt-actions/buildkite/download-artifact@v1.5.0
         with:
-          name: signed-artifacts
+          build-number: ${{ steps.buildkite-run.outputs.build }}
+          path: ${{ env.TARBALL_FILE }}
+          pipeline: ${{ steps.buildkite-run.outputs.pipeline }}
+          token: ${{ secrets.BUILDKITE_TOKEN }}
 
       - name: untar the buildkite tarball
         run: tar xvf ${{ env.TARBALL_FILE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,15 +63,7 @@ jobs:
 
   test-release:
     runs-on: ubuntu-latest
-    # If no PR event or if a PR event that's caused by a non-fork and non dependabot actor
-    if: |
-      ( github.event_name != 'pull_request'
-        ||
-        ( github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.fork == false &&
-          github.actor != 'dependabot[bot]'
-        )
-      )
+    if: github.event_name != 'pull_request'
     permissions:
       attestations: write
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,29 +57,27 @@ jobs:
             :runner: [${{ github.repository }}] Release *${{ github.ref_name }}* has been triggered with the following params:
             ```${{ toJSON(github.event.inputs) }}```
 
-      - id: buildkite
+      - id: buildkite-run
         name: Run Release
-        uses: elastic/apm-pipeline-library/.github/actions/buildkite@current
+        uses: elastic/oblt-actions/buildkite/run@v1.5.0
         with:
-          vaultUrl: ${{ secrets.VAULT_ADDR }}
-          vaultRoleId: ${{ secrets.VAULT_ROLE_ID }}
-          vaultSecretId: ${{ secrets.VAULT_SECRET_ID }}
-          pipeline: apm-agent-android-release
-          pipelineBranch: ${{ github.ref_name }}
-          waitFor: true
-          printBuildLogs: false
-          artifactName: signed-artifacts
-          artifactPath: ${{ env.TARBALL_FILE }}
-          buildEnvVars: |
+          branch: ${{ github.ref_name }}
+          pipeline: "apm-agent-android-release"
+          token: ${{ secrets.BUILDKITE_TOKEN }}
+          wait-for: true
+          env-vars: |
             branch_specifier=${{ inputs.branch_specifier || 'main' }}
             target_specifier=${{ inputs.target_specifier || 'all' }}
             version_override_specifier=${{ inputs.version_override_specifier || '' }}
             dry_run=${{ inputs.dry_run || 'false' }}
             TARBALL_FILE=${{ env.TARBALL_FILE }}
 
-      - uses: actions/download-artifact@v3
+      - uses: elastic/oblt-actions/buildkite/download-artifact@v1.5.0
         with:
-          name: signed-artifacts
+          build-number: ${{ steps.buildkite-run.outputs.number }}
+          path: ${{ env.TARBALL_FILE }}
+          pipeline: ${{ steps.buildkite-run.outputs.pipeline }}
+          token: ${{ secrets.BUILDKITE_TOKEN }}
 
       - name: untar the buildkite tarball
         run: tar xvf ${{ env.TARBALL_FILE }}
@@ -102,7 +100,7 @@ jobs:
           secretId: ${{ secrets.VAULT_SECRET_ID }}
           channel: "#apm-agent-mobile"
           message: |
-            :tada: :rocket: [${{ github.repository }}] Release *${{ github.ref_name }}* has been successful in Buildkite: (<${{ steps.buildkite.outputs.build }}|build>)
+            :tada: :rocket: [${{ github.repository }}] Release *${{ github.ref_name }}* has been successful in Buildkite: (<${{ steps.buildkite-run.outputs.build }}|build>)
 
       - if: ${{ failure() }}
         uses: elastic/apm-pipeline-library/.github/actions/slack-message@current


### PR DESCRIPTION
No more vault access to run Buildkite jobs.

### Tasks
- [x] Support CI
- [x] Support releases

### Tests

I created a feature branch called `test/buildkite-run`:
- https://github.com/elastic/apm-agent-android/pull/328
