### PR TITLE
ci: use GitHub app for ephemeral tokens

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,16 +110,30 @@ jobs:
     name: Post Release
     needs: release
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    env:
-      GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
     steps:
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write",
+              "pull_requests": "write"
+            }
+          repositories: >-
+            ["${{github.repository}}"]
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.branch_specifier || 'main' }}
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ steps.get_token.outputs.token }}
+
       - uses: elastic/oblt-actions/git/setup@v1
+        with:
+          github-token: ${{ steps.get_token.outputs.token }}
+
       - uses: ./.github/actions/setup
       - if: ${{ ! inputs.dry_run }}
         run: ./gradlew postDeploy -Prelease=true -Pversion_override=${{ inputs.version_override_specifier || '' }}

--- a/.github/workflows/updateVersionBranch.yml
+++ b/.github/workflows/updateVersionBranch.yml
@@ -9,21 +9,36 @@ on:
       - closed
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   if_merged_postDeploy:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.head.ref, 'post-release/')
     runs-on: ubuntu-latest
     name: Create PR to update version branch
-    env:
-      GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
     steps:
+      - name: Get token
+        id: get_token
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
+        with:
+          app_id: ${{ secrets.OBS_AUTOMATION_APP_ID }}
+          private_key: ${{ secrets.OBS_AUTOMATION_APP_PEM }}
+          permissions: >-
+            {
+              "contents": "write",
+              "pull_requests": "write"
+            }
+          repositories: >-
+            ["${{github.repository}}"]
+
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ steps.get_token.outputs.token }}
 
       - uses: elastic/oblt-actions/git/setup@v1
+        with:
+          github-token: ${{ steps.get_token.outputs.token }}
 
       - uses: actions-ecosystem/action-regex-match@v2
         id: major-version
@@ -39,5 +54,5 @@ jobs:
           git push -u origin $CONFLICT_RESOLUTION_BRANCH
           gh pr create --base ${{ env.BASE_BRANCH }} --title 'Merge main into version branch' --body 'Created by Github action :robot:' --reviewer elastic/apm-agent-android
         env:
-          GH_TOKEN: ${{ env.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.get_token.outputs.token }}
           BASE_BRANCH: "${{ steps.major-version.outputs.group1 }}.x"


### PR DESCRIPTION
#### What

Use the GitHub app to generate the required ephemeral tokens with the least permissive principle.

#### Why

* Finer-grained tokens with Service Machine accounts are required to rotate the secrets manually.
* GitHub app to generate temporary tokens is the advanced approach to avoid the above
* Document what the GH workflow requires to run in terms of access
* GitHub Token with Permissions does not trigger GitHub builds 


#### Implementation details

Use `tibdex/github-app-token` with the required permissions and the repository scope
Remove the `permissions` configuration in the GH workflow.
Configure git checkout with the ephemeral token
Configure the GH_TOKEN with the ephemeral token
