### PR TITLE
[docs] Add a note about Elastic Cloud Serverless support

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -8,6 +8,11 @@ It has a default configuration that suits most common use cases and built-in sup
 The agent is built on top of https://opentelemetry.io/[OpenTelemetry], enabling you to add custom instrumentation with the
 https://opentelemetry.io/docs/instrumentation/java/manual/[OpenTelemetry Java API].
 
+[NOTE]
+====
+The Elastic APM Android Agent is not compatible with {serverless-docs}[{serverless-full}].
+====
+
 [float]
 [[how-it-works]]
 === How does the Agent work?


### PR DESCRIPTION
Related to https://github.com/elastic/observability-docs/issues/3394

Adds a note that lets users know that the agent is not compatible with [Elastic Cloud Serverless](https://www.elastic.co/guide/en/serverless/current/intro.html).

Note: When this PR is finalized, I'll open a PR targeting `0.x`.

cc @chrisdistasio 