### PR TITLE
[docs] Fix image paths for docs-assembler

### DIFF
--- a/docs/reference/getting-started.md
+++ b/docs/reference/getting-started.md
@@ -83,23 +83,20 @@ Once your app has sent telemetry data, either [manually](manual-instrumentation.
 
 You should find your application listed there.
 
-:::{image} images/span-visualization/1.png
-:screenshot:
-:width: 350px
-:::
+% TO DO: Use `:class: screenshot`
+% TO DO: Use `:width: 350px`
+![Services](images/span-visualization/1.png)
 
 When you open it, go to the **Transactions** tab, where you should see your app's "outermost" spans listed.
 
-:::{image} images/span-visualization/2.png
-:screenshot:
-:width: 350px
-:::
+% TO DO: Use `:class: screenshot`
+% TO DO: Use `:width: 350px`
+![Transactions tab](images/span-visualization/2.png)
 
 After clicking on the span, you should see it in detail.
 
-:::{image} images/span-visualization/3.png
-:screenshot:
-:::
+% TO DO: Use `:class: screenshot`
+![Trace sample](images/span-visualization/3.png)
 
 ## What’s next? [whats-next]
 

--- a/docs/reference/how-tos.md
+++ b/docs/reference/how-tos.md
@@ -54,27 +54,23 @@ On a [Serverless deployment](https://www.elastic.co/guide/en/serverless/current/
 
 Then select **Application**, as shown below:
 
-:::{image} images/find-export-endpoint/1.png
-:screenshot:
-:::
+% TO DO: Use `:class: screenshot`
+![Add Observability data](images/find-export-endpoint/1.png)
 
 Choose **OpenTelemetry**:
 
-:::{image} images/find-export-endpoint/2.png
-:screenshot:
-:::
+% TO DO: Use `:class: screenshot`
+![Monitor with OpenTelemetry](images/find-export-endpoint/2.png)
 
 On the next page, select the **OpenTelemetry** tab, followed by **Managed OTLP Endpoint** under "Configure the OpenTelemetry SDK":
 
-:::{image} images/find-export-endpoint/3.png
-:screenshot:
-:::
+% TO DO: Use `:class: screenshot`
+![Configure the OpenTelemetry SDK](images/find-export-endpoint/3.png)
 
 Your export endpoint URL is the value for the **`OTEL_EXPORTER_OTLP_ENDPOINT`** configuration setting:
 
-:::{image} images/find-export-endpoint/4.png
-:screenshot:
-:::
+% TO DO: Use `:class: screenshot`
+![Set the OTEL_EXPORTER_OTLP_ENDPOINT](images/find-export-endpoint/4.png)
 
 ### For Cloud Hosted and self-managed deployments
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -17,9 +17,8 @@ All the features provided by the [OpenTelemetry SDK](https://github.com/open-tel
 
 Distributed tracing allows you to see the full picture of **how long your application has to wait for your backend services** to provide a response (and why), as shown in the example below:
 
-:::{image} images/intro/distributed-tracing.png
-:screenshot:
-:::
+% TO DO: Use `:class: screenshot`
+![Distributed tracing](images/intro/distributed-tracing.png)
 
 The previous image shows **3 spans** from {{kib}}:
 


### PR DESCRIPTION
Fixes image paths to work with docs-assembler.

Notes for the reviewer:
* I was not able to get images in reference, extend, or release-notes to work using the `:::{image}` syntax because it seems to resolve differently than the Markdown `![]()` syntax. We should address this in docs-builder, but in order to get images working as soon as possible, I've used Markdown syntax and left us a `TO DO` in a code comment to add back the `screenshot` class where applicable. 
* Can you please add the appropriate labels needed for backporting? 