### PR TITLE
docs-builder: add `pull-requests: write` permission to docs-build workflow

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -15,4 +15,4 @@ jobs:
       deployments: write
       id-token: write
       contents: read
-      pull-requests: read
+      pull-requests: write


### PR DESCRIPTION
## Details

⚠️ This PR was created by an automated tool. Please review the changes carefully. ⚠️ 

Add permissions `pull-requests: write` to the docs-build workflow.

## Why

We want to comment on the PR with the links to modified docs pages.

   See https://github.com/elastic/docs-builder/issues/1395 for further details
