### PR TITLE
Adding min Kotlin version compatibility

### DIFF
--- a/build-tools/src/main/kotlin/elastic.android-library.gradle.kts
+++ b/build-tools/src/main/kotlin/elastic.android-library.gradle.kts
@@ -1,5 +1,7 @@
 import com.android.build.api.variant.HasHostTestsBuilder
 import com.android.build.api.variant.HostTestBuilder
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
     id("com.android.library")
@@ -7,6 +9,8 @@ plugins {
     id("elastic.animalsniffer-android")
 }
 
+val javaVersionStr = project.property("elastic.java.compatibility") as String
+val minKotlinVersionStr = project.property("elastic.kotlin.compatibility") as String
 android {
     compileSdk = (project.property("elastic.android.compileSdk") as String).toInt()
 
@@ -15,18 +19,23 @@ android {
         consumerProguardFiles.add(rootProject.file("shared-rules.pro"))
     }
 
-    val javaVersionStr = project.property("elastic.java.compatibility") as String
     val javaVersion = JavaVersion.toVersion(javaVersionStr)
     compileOptions {
         sourceCompatibility = javaVersion
         targetCompatibility = javaVersion
     }
-    kotlinOptions {
-        jvmTarget = javaVersionStr
-        freeCompilerArgs = listOf("-Xjvm-default=all")
-    }
     lint {
         disable.add("NewApi")
+    }
+}
+
+val minKotlinVersion = KotlinVersion.fromVersion(minKotlinVersionStr)
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.fromTarget(javaVersionStr)
+        apiVersion = minKotlinVersion
+        languageVersion = minKotlinVersion
+        freeCompilerArgs = listOf("-Xjvm-default=all")
     }
 }
 

--- a/build-tools/src/main/kotlin/elastic.java-library.gradle.kts
+++ b/build-tools/src/main/kotlin/elastic.java-library.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
 plugins {
     id("java-library")
@@ -6,14 +7,18 @@ plugins {
 }
 
 val javaVersionStr = project.property("elastic.java.compatibility") as String
+val minKotlinVersionStr = project.property("elastic.kotlin.compatibility") as String
 val javaVersion = JavaVersion.toVersion(javaVersionStr)
 java {
     sourceCompatibility = javaVersion
     targetCompatibility = javaVersion
 }
 
+val minKotlinVersion = KotlinVersion.fromVersion(minKotlinVersionStr)
 kotlin.compilerOptions {
     jvmTarget.set(JvmTarget.fromTarget(javaVersionStr))
+    apiVersion = minKotlinVersion
+    languageVersion = minKotlinVersion
     freeCompilerArgs = listOf("-Xjvm-default=all")
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,5 @@ android.useAndroidX=true
 elastic.android.minSdk=21
 elastic.android.compileSdk=35
 elastic.java.compatibility=11
+elastic.kotlin.compatibility=1.9
 group=co.elastic.otel.android


### PR DESCRIPTION
Based on [this issue](https://github.com/elastic/apm-agent-android/issues/574#issuecomment-3101935422).