### PR TITLE
Clean up test filter

### DIFF
--- a/instrumentation-test/instrumentation/oteladapter/src/androidTest/java/co/elastic/otel/android/test/oteladapter/InstrumentationTest.kt
+++ b/instrumentation-test/instrumentation/oteladapter/src/androidTest/java/co/elastic/otel/android/test/oteladapter/InstrumentationTest.kt
@@ -21,7 +21,7 @@ class InstrumentationTest {
 
             agentRule.flushLogs().join(5, TimeUnit.SECONDS)
 
-            val finishedLogRecords = agentRule.getFinishedLogRecords().filter { it.eventName == null }
+            val finishedLogRecords = agentRule.getFinishedLogRecords()
             Assertions.assertThat(finishedLogRecords).hasSize(1)
             OpenTelemetryAssertions.assertThat(finishedLogRecords.first())
                 .hasBody("My log")


### PR DESCRIPTION
It was added as a workaround for an issue introduced in OTel Android 1.5.0, but it has been patched now, so it's no longer needed.