### PR TITLE
Bumping bytebuddy and updating its renovate rules

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 opentelemetry = "1.63.0"
 opentelemetry-contrib = "1.58.0-alpha"
-byteBuddy = "1.18.10"
+byteBuddy = "1.18.11"
 kotlin = "2.4.0"
 android = "9.2.1"
 

--- a/renovate.json
+++ b/renovate.json
@@ -45,6 +45,12 @@
       ],
       "ignoreUnstable": false,
       "groupName": "otel-android"
+    },
+    {
+      "matchPackageNames": [
+        "net.bytebuddy:*"
+      ],
+      "allowedVersions": "!/-jdk5$/"
     }
   ]
 }


### PR DESCRIPTION
Supersedes https://github.com/elastic/apm-agent-android/pull/848 and avoids using the "-jdk5" suffixed versions in the future.