### PR TITLE
docs: rename EDOT to Elastic OTel Android for 9.5 rebrand

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -11,9 +11,9 @@ toc:
   - toc: reference/edot-android
 subs:
   motlp: Elastic Cloud Managed OTLP Endpoint
-  edot: Elastic Distribution of OpenTelemetry
+  edot: Elastic OpenTelemetry
   ecloud:   "Elastic Cloud"
-  edot-cf:   "EDOT Cloud Forwarder"
+  edot-cf:   "Elastic Cloud Forwarder"
   ech:   "Elastic Cloud Hosted"
   ess:   "Elasticsearch Service"
   ece:   "Elastic Cloud Enterprise"

--- a/docs/reference/edot-android/automatic-instrumentation.md
+++ b/docs/reference/edot-android/automatic-instrumentation.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Automatic instrumentation
-description: Instrument Android applications automatically using EDOT Android.
+description: Instrument Android applications automatically using Elastic OTel Android.
 applies_to:
   stack:
   serverless:
@@ -15,9 +15,9 @@ mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/android/current/supported-technologies.html
 ---
 
-# Automatic instrumentation for Android with EDOT SDK
+# Automatic instrumentation for Android with Elastic OTel SDK [automatic-instrumentation-for-android-with-edot-sdk]
 
-EDOT Android can automatically generate telemetry on your behalf. This allows you to get telemetry data for supported targets without having to write [manual instrumentation](manual-instrumentation.md).
+Elastic OTel Android can automatically generate telemetry on your behalf. This allows you to get telemetry data for supported targets without having to write [manual instrumentation](manual-instrumentation.md).
 
 ## Installation [supported-instrumentations-installation]
 
@@ -27,9 +27,9 @@ To install a supported automatic instrumentation, follow these steps:
 
 1. Choose a [supported instrumentation](#supported-instrumentations).
 2. Add its Gradle plugin to your project in the same location where the [agent](getting-started.md#gradle-setup) is added.
-3. [Initialize EDOT Android](getting-started.md#agent-setup) the same way you would without using automatic instrumentation.
+3. [Initialize Elastic OTel Android](getting-started.md#agent-setup) the same way you would without using automatic instrumentation.
 
-Automatic instrumentations will get installed during EDOT Android's initialization.
+Automatic instrumentations will get installed during Elastic OTel Android's initialization.
 
 ```{tip}
 You can also use instrumentations from [OpenTelemetry Android](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation) through the [OTel Android instrumentation adapter](#adapter-for-otel-android-instrumentations).
@@ -39,7 +39,7 @@ You can also use instrumentations from [OpenTelemetry Android](https://github.co
 
 Some automatic instrumentations perform bytecode instrumentation, also known as _bytecode weaving_, where your application's code, including code from the libraries it uses, is modified at compile-time. This is similar to what `isMinifyEnabled` does with R8 functionalities, automating code changes that you would otherwise need to make manually. 
 
-Bytecode instrumentation is a common technique which may already be used in your project for use cases such as [code optimization](https://developer.android.com/build/shrink-code#optimization) through R8. While useful, bytecode instrumentation can make compilation take longer to complete. Because of this, EDOT Android provides [a way to disable](#automatic-instrumentation-configuration) bytecode instrumentation for specific build types or product flavors.
+Bytecode instrumentation is a common technique which may already be used in your project for use cases such as [code optimization](https://developer.android.com/build/shrink-code#optimization) through R8. While useful, bytecode instrumentation can make compilation take longer to complete. Because of this, Elastic OTel Android provides [a way to disable](#automatic-instrumentation-configuration) bytecode instrumentation for specific build types or product flavors.
 
 ## Configuration [automatic-instrumentation-configuration]
 
@@ -151,14 +151,14 @@ dependencies {  // <2>
 
 1. Make sure the adapter is added.
 2. You can find the dependencies needed in the [instrumentation's README file](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/httpurlconnection#project-dependencies). The same will be the case for any other instrumentation.
-3. The instrumentations that require a `byteBuddy` dependency, do bytecode weaving, as explained in [compilation behavior](#compilation-behavior). An extra plugin named `net.bytebuddy.byte-buddy-gradle-plugin` is required to make this work, as shown [here](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/httpurlconnection#byte-buddy-compilation-plugin). However, EDOT Android installs this extra plugin on your behalf, so there's no need for you to do so manually.
+3. The instrumentations that require a `byteBuddy` dependency, do bytecode weaving, as explained in [compilation behavior](#compilation-behavior). An extra plugin named `net.bytebuddy.byte-buddy-gradle-plugin` is required to make this work, as shown [here](https://github.com/open-telemetry/opentelemetry-android/tree/main/instrumentation/httpurlconnection#byte-buddy-compilation-plugin). However, Elastic OTel Android installs this extra plugin on your behalf, so there's no need for you to do so manually.
 
 ### Compilation performance
 
 As explained in [compilation behavior](#compilation-behavior), the instrumentations that perform bytecode weaving might increase the
-compilation times. Because of this, EDOT Android provides a [configuration param](#automatic-instrumentation-configuration)
+compilation times. Because of this, Elastic OTel Android provides a [configuration param](#automatic-instrumentation-configuration)
 that allows to select specific build types for which the bytecode instrumentation will be turned off. This configuration
-only works for EDOT Android's [supported instrumentations](#supported-instrumentations), so it won't have any effect on
+only works for Elastic OTel Android's [supported instrumentations](#supported-instrumentations), so it won't have any effect on
 instrumentations added through the OTel Android instrumentations adapter.
 
 To select the build variant to run the bytecode instrumentation for an OTel Android instrumentation, you must

--- a/docs/reference/edot-android/configuration.md
+++ b/docs/reference/edot-android/configuration.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Configuration
-description: Comprehensive list of configuration parameters for the Elastic Distribution of OpenTelemetry Android (EDOT Android).
+description: Comprehensive list of configuration parameters for the Elastic OTel Android SDK.
 applies_to:
   stack:
   serverless:
@@ -15,13 +15,13 @@ mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/android/current/configuration.html
 ---
 
-# Configure the EDOT Android SDK [configuration]
+# Configure the Elastic OTel Android SDK [configuration]
 
-This section contains a comprehensive list of all the configurable parameters available for EDOT Android, including those you can set during initialization and those you can adjust dynamically afterward.
+This section contains a comprehensive list of all the configurable parameters available for Elastic OTel Android, including those you can set during initialization and those you can adjust dynamically afterward.
 
 ## Initialization configuration 
 
-Initialization configuration is available from the EDOT Android builder shown in [Agent setup](getting-started.md#agent-setup). The following are its available parameters.
+Initialization configuration is available from the Elastic OTel Android builder shown in [Agent setup](getting-started.md#agent-setup). The following are its available parameters.
 
 ### Application metadata
 
@@ -81,10 +81,10 @@ To provide these values from outside of your code, using an environment variable
 
 ### TLS connections
 
-EDOT Android supports TLS connections to OTLP endpoints and OpAMP (central configuration) endpoints when the server uses a TLS certificate signed by a trusted Certificate Authority (CA).
+Elastic OTel Android supports TLS connections to OTLP endpoints and OpAMP (central configuration) endpoints when the server uses a TLS certificate signed by a trusted Certificate Authority (CA).
 
 :::{warning}
-Self-signed certificates are **not supported**. If your endpoint uses a self-signed certificate, EDOT Android will not be able to establish a secure connection. Ensure your server uses a certificate issued by a publicly trusted CA or an internal CA that is trusted by the device.
+Self-signed certificates are **not supported**. If your endpoint uses a self-signed certificate, Elastic OTel Android will not be able to establish a secure connection. Ensure your server uses a certificate issued by a publicly trusted CA or an internal CA that is trusted by the device.
 :::
 
 ### Intercept export request headers
@@ -173,7 +173,7 @@ class MyApp : android.app.Application {
 
 ### Intercept resources
 
-EDOT Android creates a [resource](https://opentelemetry.io/docs/specs/otel/overview/#resources) for your signals, which is a set of static global attributes. These attributes help {{kib}} properly display your application's data.
+Elastic OTel Android creates a [resource](https://opentelemetry.io/docs/specs/otel/overview/#resources) for your signals, which is a set of static global attributes. These attributes help {{kib}} properly display your application's data.
 
 You can intercept these resources and read or modify them as shown in the following example.
 
@@ -198,7 +198,7 @@ The resource interceptor is only applied during initialization, as this is the o
 
 ### Intercept exporters
 
-EDOT Android configures exporters for each signal ([spans](https://opentelemetry.io/docs/languages/java/sdk/#spanexporter), [logs](https://opentelemetry.io/docs/languages/java/sdk/#logrecordexporter), and [metrics](https://opentelemetry.io/docs/languages/java/sdk/#metricexporter)) to manage features like [disk buffering](index.md#disk-buffering) and also to establish a connection with the Elastic export endpoint based on the provided [export connectivity](#export-connectivity) values.
+Elastic OTel Android configures exporters for each signal ([spans](https://opentelemetry.io/docs/languages/java/sdk/#spanexporter), [logs](https://opentelemetry.io/docs/languages/java/sdk/#logrecordexporter), and [metrics](https://opentelemetry.io/docs/languages/java/sdk/#metricexporter)) to manage features like [disk buffering](index.md#disk-buffering) and also to establish a connection with the Elastic export endpoint based on the provided [export connectivity](#export-connectivity) values.
 
 You can intercept exporters to add your own logic, such as logging each signal that gets exported, or filtering some items that don't make sense for you to export. For example:
 
@@ -221,7 +221,7 @@ class MyApp : android.app.Application {
 
 ### Intercept HTTP spans
 
-This is a convenience tool to intercept HTTP-related spans. By default, EDOT Android enhances HTTP span names to include `domain:port` when only an HTTP verb is set. This is [often the case](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name) for HTTP client span names.
+This is a convenience tool to intercept HTTP-related spans. By default, Elastic OTel Android enhances HTTP span names to include `domain:port` when only an HTTP verb is set. This is [often the case](https://opentelemetry.io/docs/specs/semconv/http/http-spans/#name) for HTTP client span names.
 
 You can override this behavior by setting your own interceptor, or you can choose to set it to `null` to just turn it off. For example:
 
@@ -242,7 +242,7 @@ class MyApp : android.app.Application {
 
 ### Provide processors
 
-Part of the work that EDOT Android does when configuring the OpenTelemetry SDK on your behalf is to provide processors, which are needed to delegate data to the exporters. For spans, EDOT Android provides a [BatchSpanProcessor](https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-trace/latest/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.html); for logs, a [BatchLogRecordProcessor](https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-logs/latest/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.html); whereas for metrics, it's a [PeriodicMetricReader](https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-metrics/latest/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.html), which is analogous to a processor.
+Part of the work that Elastic OTel Android does when configuring the OpenTelemetry SDK on your behalf is to provide processors, which are needed to delegate data to the exporters. For spans, Elastic OTel Android provides a [BatchSpanProcessor](https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-trace/latest/io/opentelemetry/sdk/trace/export/BatchSpanProcessor.html); for logs, a [BatchLogRecordProcessor](https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-logs/latest/io/opentelemetry/sdk/logs/export/BatchLogRecordProcessor.html); whereas for metrics, it's a [PeriodicMetricReader](https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-sdk-metrics/latest/io/opentelemetry/sdk/metrics/export/PeriodicMetricReader.html), which is analogous to a processor.
 
 If you want to provide your own processors, you can do so by setting a custom [ProcessorFactory](https://github.com/elastic/apm-agent-android/blob/main/agent-sdk/src/main/java/co/elastic/otel/android/processors/ProcessorFactory.kt), as shown in the example:
 
@@ -266,12 +266,12 @@ The factory is called once during initialization and needs to provide a processo
 ### Internal logging policy
 
 :::{note}
-Not to be confused with OpenTelemetry's [log signals](https://opentelemetry.io/docs/concepts/signals/logs/). The internal logging policy is about EDOT Android's internal logs that you should see in [logcat](https://developer.android.com/studio/debug/logcat) only.
+Not to be confused with OpenTelemetry's [log signals](https://opentelemetry.io/docs/concepts/signals/logs/). The internal logging policy is about Elastic OTel Android's internal logs that you should see in [logcat](https://developer.android.com/studio/debug/logcat) only.
 :::
 
-EDOT Android creates logs using [Android's Log](https://developer.android.com/reference/android/util/Log) type to notify about its internal events, so that you can check them out in [logcat](https://developer.android.com/studio/debug/logcat) for debugging purposes. By default, all logs are printed for a debuggable app build. However, in the case of non-debuggable builds, only logs at the `INFO` level and higher are printed.
+Elastic OTel Android creates logs using [Android's Log](https://developer.android.com/reference/android/util/Log) type to notify about its internal events, so that you can check them out in [logcat](https://developer.android.com/studio/debug/logcat) for debugging purposes. By default, all logs are printed for a debuggable app build. However, in the case of non-debuggable builds, only logs at the `INFO` level and higher are printed.
 
-If you want to show specific logs from EDOT Android, or even turn off logs altogether, you can do so by providing your own `LoggingPolicy` configuration. The following example shows how to allow all logs of level `WARN` and higher to be printed, whereas those lower than `WARN` are ignored.
+If you want to show specific logs from Elastic OTel Android, or even turn off logs altogether, you can do so by providing your own `LoggingPolicy` configuration. The following example shows how to allow all logs of level `WARN` and higher to be printed, whereas those lower than `WARN` are ignored.
 
 ```kotlin
 import co.elastic.otel.android.ElasticApmAgent
@@ -296,9 +296,9 @@ Gradle configuration is available from the `elasticOtel` block. These values are
 
 ### Build ID
 
-EDOT Android adds the `app.build_id` resource attribute to telemetry when the Gradle plugin is applied. This value can be used to correlate application telemetry with build artifacts.
+Elastic OTel Android adds the `app.build_id` resource attribute to telemetry when the Gradle plugin is applied. This value can be used to correlate application telemetry with build artifacts.
 
-By default, EDOT Android generates the build ID from the app's final application ID, version name, and version code:
+By default, Elastic OTel Android generates the build ID from the app's final application ID, version name, and version code:
 
 ```text
 sha256("<applicationId>-<versionName>-<versionCode>")
@@ -330,7 +330,7 @@ android {
 }
 ```
 
-When multiple values match a variant, EDOT Android uses the most specific value in this order: build type, product flavor, project-level `elasticOtel`, then the generated default.
+When multiple values match a variant, Elastic OTel Android uses the most specific value in this order: build type, product flavor, project-level `elasticOtel`, then the generated default.
 
 ## Dynamic configuration
 
@@ -364,11 +364,11 @@ product:
   edot_android: preview 1.2.0
 ```
 
-Starting from version `1.2.0`, you can remotely manage the EDOT Android behavior through [Central configuration](opentelemetry://reference/central-configuration.md).
+Starting from version `1.2.0`, you can remotely manage the Elastic OTel Android behavior through [Central configuration](opentelemetry://reference/central-configuration.md).
 
 ### Activate central configuration
 
-The remote management is turned off by default. To turn it on, provide your central configuration endpoint when initializing EDOT Android, as shown here:
+The remote management is turned off by default. To turn it on, provide your central configuration endpoint when initializing Elastic OTel Android, as shown here:
 
 ```kotlin
 import co.elastic.otel.android.ElasticApmAgent
@@ -387,16 +387,16 @@ class MyApp : android.app.Application {
 }
 ```
 
-1. Provide your EDOT Collector OpAMP endpoint. Refer to [Central configuration](opentelemetry://reference/central-configuration.md) for more details.
+1. Provide your {{agent}} OpAMP endpoint. Refer to [Central configuration](opentelemetry://reference/central-configuration.md) for more details.
 2. In case your OpAMP endpoint [requires authentication](elastic-agent://reference/edot-collector/config/default-config-standalone.md#authentication-settings), this is how you can provide your API Key value.
 
 ### Available settings
 
-You can modify the following settings for EDOT Android through the Central Configuration:
+You can modify the following settings for Elastic OTel Android through the Central Configuration:
 
 | Setting | Central configuration name | Description | Type |
 |---------|----------------------------|-------------|------|
-| Recording | `recording` | Whether EDOT Android should record and export telemetry or not. By default it's enabled, disabling it is effectively turning EDOT Android off where only the central configuration polling will be performed. | Dynamic |
+| Recording | `recording` | Whether Elastic OTel Android should record and export telemetry or not. By default it's enabled, disabling it is effectively turning Elastic OTel Android off where only the central configuration polling will be performed. | Dynamic |
 | Session sample rate | `session_sample_rate` | To reduce overhead and storage requirements, you can set the sample rate to a value between 0.0 and 1.0. Data will be sampled per session, this is so context in a given session isn't lost. | Dynamic |
 
 Dynamic settings can be changed without having to restart the application.
@@ -438,7 +438,7 @@ You've properly created build config fields from environment variables. To use t
 
 ### Provide data from a properties file
 
-[Properties](https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html) are a common way to provide values to JVM apps through files. Here's an example of how you could use them to provide config values to EDOT Android.
+[Properties](https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html) are a common way to provide values to JVM apps through files. Here's an example of how you could use them to provide config values to Elastic OTel Android.
 
 Given the following example properties file:
 

--- a/docs/reference/edot-android/getting-started.md
+++ b/docs/reference/edot-android/getting-started.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Get started
-description: Set up the Elastic Distribution of OpenTelemetry Android (EDOT Android) to send data to Elastic.
+description: Set up Elastic OTel Android to send data to Elastic.
 applies_to:
   stack:
   serverless:
@@ -15,9 +15,9 @@ mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/android/current/setup.html
 ---
 
-# Get started with EDOT Android
+# Get started with Elastic OTel Android [get-started-with-edot-android]
 
-Set up the Elastic Distribution of OpenTelemetry Android (EDOT Android) in your app and explore your app's data in {{kib}}.
+Set up Elastic OTel Android in your app and explore your app's data in {{kib}}.
 
 ## Requirements
 
@@ -28,12 +28,12 @@ Set up the Elastic Distribution of OpenTelemetry Android (EDOT Android) in your 
 
 :::{important}
 * If your application's [minSdk](https://developer.android.com/studio/publish/versioning#minsdk) value is lower than 26, you must add [Java 8 desugaring support](https://developer.android.com/studio/write/java8-support#library-desugaring). Refer to [Troubleshooting](docs-content://troubleshoot/ingest/opentelemetry/edot-sdks/android/index.md#why-desugaring) for more information.
-* EDOT Android is meant to be used in Android projects only. Hybrid frameworks, such as React Native and Flutter, are not supported.
+* Elastic OTel Android is meant to be used in Android projects only. Hybrid frameworks, such as React Native and Flutter, are not supported.
 :::
 
 ## Gradle setup
 
-Add the [EDOT Android agent plugin](https://plugins.gradle.org/plugin/co.elastic.otel.android.agent) to your application’s `build.gradle[.kts]` file:
+Add the [Elastic OTel Android agent plugin](https://plugins.gradle.org/plugin/co.elastic.otel.android.agent) to your application’s `build.gradle[.kts]` file:
 
 ```kotlin
 plugins {
@@ -70,7 +70,7 @@ If you'd like to provide these values from outside of your code, using an enviro
 
 ## Start sending telemetry
 
-With EDOT Android fully initialized, you can start sending telemetry to your {{stack}}.
+With Elastic OTel Android fully initialized, you can start sending telemetry to your {{stack}}.
 
 ### Generate telemetry
 
@@ -151,8 +151,8 @@ You'll see the trace waterfall UI, showing the full span hierarchy and timing. Y
 
 ## What’s next? [whats-next]
 
-- This guide uses the minimum configuration options needed to initialize EDOT Android. If you'd like to explore what else you can customize, take a look at the [configuration page](configuration.md).
+- This guide uses the minimum configuration options needed to initialize Elastic OTel Android. If you'd like to explore what else you can customize, take a look at the [configuration page](configuration.md).
 
-- In the example, you've manually sent a span, so you've created some [manual instrumentation](manual-instrumentation.md) for your app. While this is helpful and flexible, EDOT Android can also create automatic instrumentations. This means that by simply initializing EDOT Android, it will start sending telemetry data on your behalf without you having to write code. For more details, refer to [Automatic instrumentation](automatic-instrumentation.md).
+- In the example, you've manually sent a span, so you've created some [manual instrumentation](manual-instrumentation.md) for your app. While this is helpful and flexible, Elastic OTel Android can also create automatic instrumentations. This means that by simply initializing Elastic OTel Android, it will start sending telemetry data on your behalf without you having to write code. For more details, refer to [Automatic instrumentation](automatic-instrumentation.md).
 
 - [Spans](https://opentelemetry.io/docs/concepts/signals/traces/#spans) are a great way to measure how long some method, part of a method, or even some broader transaction that involves multiple methods takes to complete. However, spans aren't the only type of [signal](https://opentelemetry.io/docs/concepts/signals/) that you can send using the agent. You can send [logs](https://opentelemetry.io/docs/concepts/signals/logs/) and [metrics](https://opentelemetry.io/docs/concepts/signals/metrics/) too! For more details, refer to [Manual instrumentation](manual-instrumentation.md).

--- a/docs/reference/edot-android/index.md
+++ b/docs/reference/edot-android/index.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: EDOT Android
-description: The Elastic Distribution of OpenTelemetry Android (EDOT Android) is an APM agent based on OpenTelemetry. It provides built-in tools and configurations to make the OpenTelemetry SDK work with Elastic using as little code as possible while fully leveraging the combined forces of Elasticsearch and Kibana for your Android application.
+navigation_title: Elastic OTel Android
+description: The Elastic OTel Android SDK is an APM agent based on OpenTelemetry. It provides built-in tools and configurations to make the OpenTelemetry SDK work with Elastic using as little code as possible while fully leveraging the combined forces of Elasticsearch and Kibana for your Android application.
 applies_to:
   stack:
   serverless:
@@ -16,11 +16,11 @@ mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/android/current/index.html
 ---
 
-# Elastic Distribution of OpenTelemetry Android
+# Elastic OTel Android [elastic-distribution-of-opentelemetry-android]
 
-The Elastic Distribution of OpenTelemetry Android (EDOT Android) is an APM agent based on [OpenTelemetry](https://opentelemetry.io/). EDOT Android provides built-in tools and configurations to make the [OpenTelemetry SDK](https://opentelemetry.io/docs/languages/java/) work with your {{stack}} using as little code as possible.
+Elastic OTel Android is an APM agent based on [OpenTelemetry](https://opentelemetry.io/). Elastic OTel Android provides built-in tools and configurations to make the [OpenTelemetry SDK](https://opentelemetry.io/docs/languages/java/) work with your {{stack}} using as little code as possible.
 
-All the features provided by the [OpenTelemetry SDK](https://github.com/open-telemetry/opentelemetry-java) are available for you to use and are pre-configured by EDOT Android to work properly out of the box. This allows you to fulfill various use cases to better understand your app's performance, such as:
+All the features provided by the [OpenTelemetry SDK](https://github.com/open-telemetry/opentelemetry-java) are available for you to use and are pre-configured by Elastic OTel Android to work properly out of the box. This allows you to fulfill various use cases to better understand your app's performance, such as:
 
 - [Distributed tracing](#distributed-tracing)
 - [Session review](#session-review)
@@ -49,20 +49,20 @@ For distributed tracing to work properly, configure your backend services to sen
 
 ## Session review [session-review]
 
-EDOT Android attaches [session](#sessions) information to each span and log generated from your application. This allows you to create queries that group all the telemetry that belongs to a session and form a session event timeline. This is useful to identify the most common actions performed by your users, as well as tracing the steps leading up to errors they might encounter.
+Elastic OTel Android attaches [session](#sessions) information to each span and log generated from your application. This allows you to create queries that group all the telemetry that belongs to a session and form a session event timeline. This is useful to identify the most common actions performed by your users, as well as tracing the steps leading up to errors they might encounter.
 
 For example, let's say you have a screen "A" in your app that can be opened from other screens, such as "B". If you create a log event when the user clicks on a button on screen "B" that takes them to screen "A", along with a log when screen "A" opens (or a span if you'd like to measure how long it takes for screen "A" to fully load), both items will contain a session.id attribute with the same value per session. This allows you to create Elasticsearch queries, for example in Kibana's Discover tool, to list all events during that session and better understand a user's journey within your application.
 
 ## Alerts, dashboards, and more [alerts-and-dashboards]
 
-Because EDOT Android also provides [direct access](manual-instrumentation.md) to the [OpenTelemetry SDK](https://opentelemetry.io/docs/languages/java/), you can generate your own data in ways that best suit your needs and take advantage of {{stack}}'s tools, such as:
+Because Elastic OTel Android also provides [direct access](manual-instrumentation.md) to the [OpenTelemetry SDK](https://opentelemetry.io/docs/languages/java/), you can generate your own data in ways that best suit your needs and take advantage of {{stack}}'s tools, such as:
 
  * [Create alerts](docs-content://explore-analyze/alerts-cases.md) when something interesting happens; for example, when an error is recorded.
  * [Build custom dashboards](docs-content://explore-analyze/dashboards.md) to display your data the way you need to see it
 
 ## Features
 
-EDOT Android provides additional features on top of those that come with the [OpenTelemetry SDK](https://opentelemetry.io/docs/languages/java/).
+Elastic OTel Android provides additional features on top of those that come with the [OpenTelemetry SDK](https://opentelemetry.io/docs/languages/java/).
 
 ### Disk buffering [disk-buffering]
 
@@ -75,11 +75,11 @@ This feature is an [automatic instrumentation](automatic-instrumentation.md), wh
 
 ### Central configuration
 
-You can remotely manage how EDOT Android behaves through {{kib}}. Refer to [Central configuration](configuration.md#central-configuration) for more details.
+You can remotely manage how Elastic OTel Android behaves through {{kib}}. Refer to [Central configuration](configuration.md#central-configuration) for more details.
 
 ### Real time [real-time]
 
-For [distributed tracing](#distributed-tracing) to work properly, your application's time should be in sync with the [coordinated universal time](https://en.wikipedia.org/wiki/Coordinated_Universal_Time). This is sometimes an issue for Android applications, as the time provided by the OS is often not accurate enough. EDOT Android aims to synchronize telemetry timestamps with the universal time to ensure a reliable view of event timelines.
+For [distributed tracing](#distributed-tracing) to work properly, your application's time should be in sync with the [coordinated universal time](https://en.wikipedia.org/wiki/Coordinated_Universal_Time). This is sometimes an issue for Android applications, as the time provided by the OS is often not accurate enough. Elastic OTel Android aims to synchronize telemetry timestamps with the universal time to ensure a reliable view of event timelines.
 
 ### Sessions [sessions]
 
@@ -89,11 +89,11 @@ A session is created when no previous session exists or when the previous one ha
 
 ### Dynamic configuration [dynamic-configuration]
 
-EDOT Android allows you to modify some values after its initialization has finished. Refer to [configuration](configuration.md).
+Elastic OTel Android allows you to modify some values after its initialization has finished. Refer to [configuration](configuration.md).
 
 ### Automatic instrumentation [automatic-instrumentation]
 
-EDOT Android provides extensions that automatically generate telemetry for common tools and use cases. Refer to [Automatic Instrumentation](automatic-instrumentation.md) for more details.
+Elastic OTel Android provides extensions that automatically generate telemetry for common tools and use cases. Refer to [Automatic Instrumentation](automatic-instrumentation.md) for more details.
 
 ## Try it out
 

--- a/docs/reference/edot-android/manual-instrumentation.md
+++ b/docs/reference/edot-android/manual-instrumentation.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: Manual instrumentation
-description: Learn how to manually instrument Android applications using the Elastic Distribution of OpenTelemetry SDK to capture spans, add attributes, and send trace data to Elastic.
+description: Learn how to manually instrument Android applications using the Elastic OTel SDK to capture spans, add attributes, and send trace data to Elastic.
 applies_to:
   stack:
   serverless:
@@ -15,17 +15,17 @@ mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/android/current/manual-instrumentation.html
 ---
 
-# Manual instrumentation using the Elastic Distribution of OpenTelemetry Android
+# Manual instrumentation using Elastic OTel Android [manual-instrumentation-using-the-elastic-distribution-of-opentelemetry-android]
 
-Learn how to manually instrument Android applications using the Elastic Distribution of OpenTelemetry SDK to capture spans, add attributes, and send trace data to Elastic.
+Learn how to manually instrument Android applications using the Elastic OTel SDK to capture spans, add attributes, and send trace data to Elastic.
 
 You can create your custom spans, metrics, and logs, using the [OpenTelemetry SDK APIs](https://opentelemetry.io/docs/languages/java/api/#opentelemetry-api), which you can find in the [OpenTelemetry](https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-api/latest/io/opentelemetry/api/OpenTelemetry.html) object provided through the `getOpenTelemetry()` method. 
 
-Alternatively, for common operations, you can use the [convenience EDOT Android extensions](#convenience-extensions) to create telemetry in a less verbose way.
+Alternatively, for common operations, you can use the [convenience Elastic OTel Android extensions](#convenience-extensions) to create telemetry in a less verbose way.
 
 ## OpenTelemetry APIs
 
-After completing the [setup](getting-started.md) process, EDOT Android has configured an [OpenTelemetry](https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-api/latest/io/opentelemetry/api/OpenTelemetry.html) object for you, which is available through the `getOpenTelemetry()` method. 
+After completing the [setup](getting-started.md) process, Elastic OTel Android has configured an [OpenTelemetry](https://www.javadoc.io/doc/io.opentelemetry/opentelemetry-api/latest/io/opentelemetry/api/OpenTelemetry.html) object for you, which is available through the `getOpenTelemetry()` method. 
 
 Here's an example of how to create telemetry using the OpenTelemetry Java APIs:
 
@@ -59,7 +59,7 @@ For more details on creating signals using the OpenTelemetry APIs, refer to the 
 
 ## Convenience extensions
 
-For common use cases, such as spans and logs creation, EDOT Android provides a couple of Kotlin extension methods to allow you to create telemetry in a less verbose way.
+For common use cases, such as spans and logs creation, Elastic OTel Android provides a couple of Kotlin extension methods to allow you to create telemetry in a less verbose way.
 
 The convenience methods make use of the same [OpenTelemetry APIs](#opentelemetry-apis) internally to create telemetry. While they're not the only way to create the following signals, they make it easier to create them.
 

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -1,6 +1,6 @@
 ---
-navigation_title: "EDOT Android"
-description: Release notes for the Elastic Distribution of OpenTelemetry Android.
+navigation_title: "Elastic OTel Android"
+description: Release notes for Elastic OTel Android.
 applies_to:
   stack:
   serverless:
@@ -14,7 +14,7 @@ mapped_pages:
   - https://www.elastic.co/guide/en/apm/agent/android/current/release-notes-0.x.html
 ---
 
-# Elastic Distribution of OpenTelemetry Android release notes
+# Elastic OTel Android release notes [elastic-distribution-of-opentelemetry-android-release-notes]
 
 Review the changes, fixes, and more in each version of {{edot}} Android.
 

--- a/docs/release-notes/known-issues.md
+++ b/docs/release-notes/known-issues.md
@@ -1,6 +1,6 @@
 ---
 navigation_title: "Known issues"
-description: Known issues for the Elastic Distribution of OpenTelemetry Android.
+description: Known issues for Elastic OTel Android.
 applies_to:
   stack:
   serverless:
@@ -11,7 +11,7 @@ products:
   - id: edot-sdk
 ---
 
-# Elastic Distribution of OpenTelemetry Android known issues
+# Elastic OTel Android known issues [elastic-distribution-of-opentelemetry-android-known-issues]
 
 Known issues are significant defects or limitations that may impact your implementation. These issues are actively being worked on and will be addressed in a future release. Review known issues to help you make informed decisions, such as upgrading to a new version.
 


### PR DESCRIPTION
## Summary

- Prose-only rebrand of all `docs/` Markdown files and `docset.yml` substitution entries for the 9.5 GA release (July 28, 2026).
- Machine identifiers are **unchanged**: `applies_to` product IDs (`edot_android`, `edot-sdk`, etc.), URL path slugs (`edot-android/`), code-block symbols, env vars, class names, and package names are all preserved.
- Pre-9.5 changelog entries in `docs/release-notes/index.md` are preserved as a historical record (the single `EDOT Collector` reference in the 1.0.0 entry remains intentionally).
- Old heading slugs are retained via explicit anchors (e.g. `[elastic-distribution-of-opentelemetry-android]`) so existing deep-links continue to resolve.
- `docset.yml` subs updated: `edot` → `Elastic OpenTelemetry`, `edot-cf` → `Elastic Cloud Forwarder`.

## Files changed (8)

- `docs/docset.yml` — subs updated
- `docs/reference/edot-android/index.md`
- `docs/reference/edot-android/getting-started.md`
- `docs/reference/edot-android/automatic-instrumentation.md`
- `docs/reference/edot-android/configuration.md`
- `docs/reference/edot-android/manual-instrumentation.md`
- `docs/release-notes/index.md`
- `docs/release-notes/known-issues.md`

## Held as draft for coordinated merge on July 28, 2026 (9.5 GA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)