### PR TITLE
Update dependencies

### DIFF
--- a/agent-plugin/src/test/java/co/elastic/otel/android/plugin/ElasticPluginFunctionalTest.kt
+++ b/agent-plugin/src/test/java/co/elastic/otel/android/plugin/ElasticPluginFunctionalTest.kt
@@ -576,7 +576,7 @@ class ElasticPluginFunctionalTest {
         // Each AGP version loads a large number of classes; without extra metaspace the Gradle
         // daemon running test builds runs OOM when sequential test invocations reuse the daemon.
         projectDir.resolve("gradle.properties").toFile().writeText(
-            "org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m\n",
+            "org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=1g\n",
         )
         projectDir.resolve("settings.gradle.kts").toFile().writeText(
             """

--- a/agent-sdk/src/test/resources/robolectric.properties
+++ b/agent-sdk/src/test/resources/robolectric.properties
@@ -1,0 +1,2 @@
+# Use the newest SDK supported by Robolectric, independently of compileSdk.
+sdk=NEWEST_SDK

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ org.gradle.jvmargs=-XX\:MaxMetaspaceSize\=2G
 version=1.9.0
 android.useAndroidX=true
 elastic.android.minSdk=23
-elastic.android.compileSdk=36
+elastic.android.compileSdk=37
 elastic.java.compatibility=11
 elastic.kotlin.compatibility=2.0
 elastic.plugin.java.compatibility=17

--- a/gradle/instrumentation.versions.toml
+++ b/gradle/instrumentation.versions.toml
@@ -15,7 +15,7 @@ androidx-test-core = "androidx.test:core-ktx:1.7.0"
 androidx-test-rules = "androidx.test:rules:1.7.0"
 androidx-test-runner = "androidx.test:runner:1.7.0"
 androidx-test-ext = "androidx.test.ext:junit:1.3.0"
-mockWebServer = "com.squareup.okhttp3:mockwebserver:5.4.0"
+mockWebServer = "com.squareup.okhttp3:mockwebserver:5.5.0"
 
 [bundles]
 androidTest = ["androidx-test-rules", "androidx-test-runner", "androidx-test-ext", "androidx-test-core"]

--- a/gradle/instrumentation.versions.toml
+++ b/gradle/instrumentation.versions.toml
@@ -5,9 +5,9 @@ opentelemetry-instrumentation-alpha = "2.31.1-alpha"
 opentelemetry-instrumentation-api = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:2.31.1"
 opentelemetry-instrumentation-api-incubator = { module = "io.opentelemetry.instrumentation:opentelemetry-instrumentation-api-incubator", version.ref = "opentelemetry-instrumentation-alpha" }
 opentelemetry-instrumentation-okhttp = { module = "io.opentelemetry.instrumentation:opentelemetry-okhttp-3.0", version.ref = "opentelemetry-instrumentation-alpha" }
-opentelemetry-android-session = { module = "io.opentelemetry.android:session", version = "1.6.0" }
+opentelemetry-android-session = { module = "io.opentelemetry.android:session", version = "1.7.0" }
 opentelemetry-android-instrumentation = { module = "io.opentelemetry.android.instrumentation:android-instrumentation", version = "1.7.0" }
-opentelemetry-android-core = { module = "io.opentelemetry.android:core", version = "1.6.0-alpha" }
+opentelemetry-android-core = { module = "io.opentelemetry.android:core", version = "1.7.0-alpha" }
 weakLockFree = "com.blogspot.mydailyjava:weak-lock-free:0.18"
 
 # Testing

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 opentelemetry = "1.65.0"
-opentelemetry-contrib = "1.59.0-alpha"
+opentelemetry-contrib = "1.60.0-alpha"
 byteBuddy = "1.18.12"
 kotlin = "2.4.20"
 android = "9.4.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ opentelemetry-sdk = { module = "io.opentelemetry:opentelemetry-sdk", version.ref
 opentelemetry-api-incubator = "io.opentelemetry:opentelemetry-api-incubator:1.65.0-alpha"
 stagemonitor-configuration = "org.stagemonitor:stagemonitor-configuration:0.89.1"
 androidx-annotations = "androidx.annotation:annotation:1.10.0"
-androidx-core = "androidx.core:core:1.18.0"
+androidx-core = "androidx.core:core:1.19.0"
 dsl-json = "com.dslplatform:dsl-json-java8:1.10.0"
 slf4j-api = "org.slf4j:slf4j-api:2.0.19"
 byteBuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "byteBuddy" }
@@ -19,7 +19,7 @@ opentelemetry-semconv-incubating = "io.opentelemetry.semconv:opentelemetry-semco
 opentelemetry-diskBuffering = { module = "io.opentelemetry.contrib:opentelemetry-disk-buffering", version.ref = "opentelemetry-contrib" }
 opentelemetry-opamp = { module = "io.opentelemetry.contrib:opentelemetry-opamp-client", version.ref = "opentelemetry-contrib" }
 opentelemetry-exporter-otlp = { module = "io.opentelemetry:opentelemetry-exporter-otlp", version.ref = "opentelemetry" }
-okhttp = "com.squareup.okhttp3:okhttp:5.4.0"
+okhttp = "com.squareup.okhttp3:okhttp:5.5.0"
 moshi = "com.squareup.moshi:moshi:1.15.2"
 moshi-kotlin = "com.squareup.moshi:moshi-kotlin:1.15.2"
 

--- a/integration-test/app/build.gradle.kts
+++ b/integration-test/app/build.gradle.kts
@@ -12,7 +12,7 @@ val withDesugaring = providers.gradleProperty("withDesugaring").map { it.toBoole
 
 android {
     namespace = "co.elastic.otel.android.integration"
-    compileSdk = 36
+    compileSdk = 37
 
     defaultConfig {
         applicationId = "co.elastic.otel.android.integration"


### PR DESCRIPTION
Supersedes https://github.com/elastic/apm-agent-android/pull/820, https://github.com/elastic/apm-agent-android/pull/878, https://github.com/elastic/apm-agent-android/pull/879, https://github.com/elastic/apm-agent-android/pull/888, https://github.com/elastic/apm-agent-android/pull/896

## Summary

Consolidate the pending dependency updates and support compiling against Android API 37 while keeping stable Robolectric.

## Changes

- Update AndroidX Core, OkHttp, MockWebServer, OpenTelemetry Contrib, and OpenTelemetry Android dependencies.
- Raise the SDK and integration app compile SDK to API 37, and make SDK unit tests default to the newest Android API supported by Robolectric.
- Increase metaspace available to the Gradle plugin functional test builds to prevent daemon exhaustion.
