### PR TITLE
Use stable deployment environment resource attribute

### DIFF
--- a/agent-sdk/src/main/java/co/elastic/otel/android/ElasticApmAgent.kt
+++ b/agent-sdk/src/main/java/co/elastic/otel/android/ElasticApmAgent.kt
@@ -170,7 +170,7 @@ class ElasticApmAgent internal constructor(
         }
 
         /**
-         * This value is set as the [deployment.environment](https://opentelemetry.io/docs/specs/semconv/attributes-registry/deployment/#deployment-environment) resource attribute.
+         * This value is set as the [deployment.environment.name](https://opentelemetry.io/docs/specs/semconv/registry/attributes/deployment/#deployment-environment-name) resource attribute.
          * It provides a place for Android applications to specify their environment/flavor or buildType.
          */
         fun setDeploymentEnvironment(value: String) = apply {

--- a/agent-sdk/src/main/java/co/elastic/otel/android/internal/opentelemetry/ElasticOpenTelemetry.kt
+++ b/agent-sdk/src/main/java/co/elastic/otel/android/internal/opentelemetry/ElasticOpenTelemetry.kt
@@ -48,9 +48,9 @@ import io.opentelemetry.sdk.metrics.internal.SdkMeterProviderUtil
 import io.opentelemetry.sdk.resources.Resource
 import io.opentelemetry.sdk.trace.SdkTracerProvider
 import io.opentelemetry.sdk.trace.export.SpanExporter
+import io.opentelemetry.semconv.DeploymentAttributes
 import io.opentelemetry.semconv.ServiceAttributes
 import io.opentelemetry.semconv.TelemetryAttributes
-import io.opentelemetry.semconv.incubating.DeploymentIncubatingAttributes
 import io.opentelemetry.semconv.incubating.DeviceIncubatingAttributes
 import io.opentelemetry.semconv.incubating.OsIncubatingAttributes
 import io.opentelemetry.semconv.incubating.ProcessIncubatingAttributes
@@ -161,7 +161,10 @@ class ElasticOpenTelemetry private constructor(
                     serviceVersion ?: serviceManager.getAppInfoService().getVersionName()
                     ?: "unknown"
                 )
-                .put(DeploymentIncubatingAttributes.DEPLOYMENT_ENVIRONMENT, deploymentEnvironment)
+                .put(
+                    DeploymentAttributes.DEPLOYMENT_ENVIRONMENT_NAME,
+                    deploymentEnvironment
+                )
                 .put(
                     AttributeKey.stringKey("app.installation.id"),
                     appInstallationIdProvider!!.get()

--- a/agent-sdk/src/test/java/co/elastic/otel/android/functional/AttributesTest.kt
+++ b/agent-sdk/src/test/java/co/elastic/otel/android/functional/AttributesTest.kt
@@ -128,7 +128,7 @@ internal class AttributesTest : ExporterProvider, ProcessorFactory {
     fun `Check resources`() {
         initialize()
         val expectedResource = Resource.builder()
-            .put("deployment.environment", "test")
+            .put("deployment.environment.name", "test")
             .put("app.build_id", BUILD_ID)
             .put("app.installation.id", "installation-id")
             .put("device.manufacturer", DEVICE_MANUFACTURER)
@@ -161,6 +161,9 @@ internal class AttributesTest : ExporterProvider, ProcessorFactory {
         assertThat(spanItems.first()).hasResource(expectedResource)
         assertThat(logItems.first()).hasResource(expectedResource)
         assertThat(metricItems.first()).hasResource(expectedResource)
+        assertThat(spanItems.first().resource.attributes)
+            .describedAs("resource containing deployment.environment.name")
+            .doesNotContainKey("deployment.environment")
     }
 
     @Test
@@ -176,7 +179,7 @@ internal class AttributesTest : ExporterProvider, ProcessorFactory {
             )
         })
         val expectedResource = Resource.builder()
-            .put("deployment.environment", "test")
+            .put("deployment.environment.name", "test")
             .put("app.build_id", BUILD_ID)
             .put("app.installation.id", "installation-id")
             .put("device.manufacturer", DEVICE_MANUFACTURER)
@@ -218,7 +221,7 @@ internal class AttributesTest : ExporterProvider, ProcessorFactory {
         setVersionName("1.2.3")
         initialize(serviceVersion = null)
         val expectedResource = Resource.builder()
-            .put("deployment.environment", "test")
+            .put("deployment.environment.name", "test")
             .put("app.build_id", BUILD_ID)
             .put("app.installation.id", "installation-id")
             .put("device.manufacturer", DEVICE_MANUFACTURER)


### PR DESCRIPTION
## Summary

Emit deployment environments using the stable OpenTelemetry resource attribute.

## Changes

- Replace the deprecated `deployment.environment` key with `deployment.environment.name`.
- Use the stable Java semantic convention constant and update the public API documentation.
- Update exported-resource tests for spans, logs, and metrics and assert that the deprecated key is absent.