### PR TITLE
Refresh Android documentation wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contributing to the Elastic APM Android agent
+# Contributing to EDOT Android
 
-The APM Agent is open source and we love to receive contributions from our community — you!
+EDOT Android is open source and we love to receive contributions from our community — you!
 
 There are many ways to contribute, from writing tutorials or blog posts, improving the
 documentation, submitting bug reports and feature requests or writing code.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# apm-agent-android
+# EDOT Android
 
-Elastic OTel Android Agent
+Elastic Distribution of OpenTelemetry Android (EDOT Android), the OpenTelemetry-based SDK for Android apps.
 
 See the [documentation](https://www.elastic.co/docs/reference/opentelemetry/edot-sdks/android) to find out more about its features, how to setup, and configuration details.
 

--- a/docs/reference/edot-android/configuration.md
+++ b/docs/reference/edot-android/configuration.md
@@ -400,7 +400,7 @@ class MyApp : android.app.Application {
 }
 ```
 
-1. Provide your EDOT Collector OpAMP endpoint. Refer to [Central configuration](opentelemetry://reference/central-configuration.md) for more details.
+1. Provide your Elastic OpAMP endpoint. Refer to [Central configuration](opentelemetry://reference/central-configuration.md) for more details.
 2. In case your OpAMP endpoint [requires authentication](elastic-agent://reference/edot-collector/config/default-config-standalone.md#authentication-settings), this is how you can provide your API Key value.
 
 ### Available settings

--- a/docs/reference/edot-android/configuration.md
+++ b/docs/reference/edot-android/configuration.md
@@ -400,7 +400,7 @@ class MyApp : android.app.Application {
 }
 ```
 
-1. Provide your Elastic OpAMP endpoint. Refer to [Central configuration](opentelemetry://reference/central-configuration.md) for more details.
+1. Provide your central configuration (OpAMP) endpoint. Refer to [Central configuration](opentelemetry://reference/central-configuration.md) for more details.
 2. In case your OpAMP endpoint [requires authentication](elastic-agent://reference/edot-collector/config/default-config-standalone.md#authentication-settings), this is how you can provide your API Key value.
 
 ### Available settings


### PR DESCRIPTION
## Summary
Refresh the Android repository documentation to use current product wording.

## Changes
- Update the README and contribution guide to present EDOT Android.
- Replace legacy central-configuration endpoint wording in the configuration reference.