### PR TITLE
fix(deps): update Robolectric to 4.17 with required JDK 17+ JVM flags

### DIFF
--- a/agent-sdk/build.gradle.kts
+++ b/agent-sdk/build.gradle.kts
@@ -15,6 +15,18 @@ android {
             isIncludeAndroidResources = true
             all {
                 it.systemProperty("agent_version", project.version)
+                // Required by Robolectric 4.17+ on JDK 17+
+                it.jvmArgs(
+                    "--add-opens=java.base/java.lang=ALL-UNNAMED",
+                    "--add-opens=java.base/java.util=ALL-UNNAMED",
+                    "--add-opens=java.base/java.io=ALL-UNNAMED",
+                    "--add-opens=java.base/java.net=ALL-UNNAMED",
+                    "--add-opens=java.base/java.security=ALL-UNNAMED",
+                    "--add-opens=java.base/java.text=ALL-UNNAMED",
+                    "--add-opens=java.base/jdk.internal.access=ALL-UNNAMED",
+                    "--add-opens=java.desktop/java.awt.font=ALL-UNNAMED",
+                    "--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED",
+                )
             }
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,7 @@ junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-launcher = { module = "org.junit.platform:junit-platform-launcher" }
 junit-engine = { module = "org.junit.jupiter:junit-jupiter-engine" }
 opentelemetry-testing = { module = "io.opentelemetry:opentelemetry-sdk-testing", version.ref = "opentelemetry" }
-robolectric = "org.robolectric:robolectric:4.16.1"
+robolectric = "org.robolectric:robolectric:4.17"
 assertj = "org.assertj:assertj-core:3.27.7"
 mockk = "io.mockk:mockk:1.14.11"
 awaitility = "org.awaitility:awaitility-kotlin:4.3.0"


### PR DESCRIPTION
Supersedes https://github.com/elastic/apm-agent-android/pull/903

## Summary

Bumps Robolectric to 4.17 and adds the JVM flags required for it to run under JDK 17+. Without the flags, Robolectric's AndroidInterceptors fails with IllegalAccessException at startup and every unit test in :agent-sdk:testDebugUnitTest crashes before executing.

## Changes

- Bump org.robolectric:robolectric from 4.16.1 to 4.17 in gradle/libs.versions.toml
- Add --add-opens JVM flags to agent-sdk/build.gradle.kts testOptions block as required by Robolectric 4.17 on JDK 17+